### PR TITLE
footer API version: use axios instead of fetchWithAuth

### DIFF
--- a/global/hooks/useHealthAPI.tsx
+++ b/global/hooks/useHealthAPI.tsx
@@ -1,23 +1,21 @@
 import { useEffect, useState } from 'react';
-import { AxiosError, AxiosResponse } from 'axios';
-import useAuthContext from './useAuthContext';
+import axios, { AxiosError, AxiosResponse } from 'axios';
 import { API } from 'global/constants/externalPaths';
+import { getConfig } from 'global/config';
+
+const { NEXT_PUBLIC_DAC_API_ROOT } = getConfig();
 
 const useHealthAPI = () => {
   const [response, setResponse] = useState<AxiosResponse | undefined>(undefined);
   const [isLoading, setIsLoading] = useState<boolean>(true);
   const [error, setError] = useState<AxiosError | undefined>(undefined);
 
-  const { fetchWithAuth } = useAuthContext();
-
   useEffect(() => {
-    fetchWithAuth({
-      url: API.HEALTH,
-    })
-      .then((res: any) => {
+    axios.get(API.HEALTH, { baseURL: NEXT_PUBLIC_DAC_API_ROOT })
+      .then((res: AxiosResponse | undefined) => {
         setResponse(res);
       })
-      .catch((err: any) => {
+      .catch((err: AxiosError | undefined) => {
         setError(err);
       })
       .finally(() => {

--- a/global/hooks/useHealthAPI.tsx
+++ b/global/hooks/useHealthAPI.tsx
@@ -6,7 +6,7 @@ import { getConfig } from 'global/config';
 const { NEXT_PUBLIC_DAC_API_ROOT } = getConfig();
 
 const axiosInstance = axios.create({
-  validateStatus: (status: number) => status == 200
+  validateStatus: (status: number) => status === 200
 });
 
 const useHealthAPI = () => {

--- a/global/hooks/useHealthAPI.tsx
+++ b/global/hooks/useHealthAPI.tsx
@@ -5,13 +5,17 @@ import { getConfig } from 'global/config';
 
 const { NEXT_PUBLIC_DAC_API_ROOT } = getConfig();
 
+const axiosInstance = axios.create({
+  validateStatus: (status: number) => status == 200
+});
+
 const useHealthAPI = () => {
   const [response, setResponse] = useState<AxiosResponse | undefined>(undefined);
   const [isLoading, setIsLoading] = useState<boolean>(true);
   const [error, setError] = useState<AxiosError | undefined>(undefined);
 
   useEffect(() => {
-    axios.get(API.HEALTH, { baseURL: NEXT_PUBLIC_DAC_API_ROOT })
+    axiosInstance.get(API.HEALTH, { baseURL: NEXT_PUBLIC_DAC_API_ROOT })
       .then((res: AxiosResponse | undefined) => {
         setResponse(res);
       })


### PR DESCRIPTION
using axios directly for the health API endpoint because it's our only no-auth API request