### PR TITLE
add appId to useApplicationsApi

### DIFF
--- a/components/Loader.tsx
+++ b/components/Loader.tsx
@@ -1,0 +1,18 @@
+import { ReactElement } from 'react';
+import { css } from '@emotion/core';
+import DnaLoader from '@icgc-argo/uikit/DnaLoader';
+
+const Loader = (): ReactElement => (
+  <figure
+    css={css`
+      align-items: center;
+      display: flex;
+      height: 100%;
+      justify-content: center;
+    `}
+  >
+    <DnaLoader />
+  </figure>
+);
+
+export default Loader;

--- a/components/pages/Applications/ApplicationForm/Header/index.tsx
+++ b/components/pages/Applications/ApplicationForm/Header/index.tsx
@@ -37,7 +37,7 @@ const ApplicationHeader = ({ data }: { data: any }): ReactElement => {
           appId={appId}
           applicant={applicant}
           createdAt={format(new Date(createdAtUtc), DATE_FORMAT)}
-          lastUpdated={format(new Date(lastUpdatedAtUtc), DATE_FORMAT + ' h:m aaaa')}
+          lastUpdated={format(new Date(lastUpdatedAtUtc), DATE_FORMAT + ' h:mm aaaa')}
         />
 
         <Progress />

--- a/components/pages/Applications/ApplicationForm/index.tsx
+++ b/components/pages/Applications/ApplicationForm/index.tsx
@@ -1,31 +1,22 @@
 import { ReactElement, useEffect, useState } from 'react';
 
-import { API } from 'global/constants';
-import { useAuthContext } from 'global/hooks';
+import Loader from 'components/Loader';
+import { useApplicationsAPI } from 'global/hooks';
 
 import ApplicationHeader from './Header';
 import ApplicationFormsBase from './Forms';
 import RequestRevisionsBar from './RequestRevisionsBar';
 
-import DnaLoader from '@icgc-argo/uikit/DnaLoader';
-
 const ApplicationForm = ({ appId = 'none', isAdmin = false }): ReactElement => {
   const [appData, setAppData] = useState({});
-  const { fetchWithAuth, isLoading } = useAuthContext();
+  const { response, isLoading } = useApplicationsAPI({ appId });
 
   useEffect(() => {
-    fetchWithAuth({
-      url: `${API.APPLICATIONS}/${appId}`,
-    })
-      .then(({ data }: { data: Record<string, any> }) => setAppData(data))
-      .catch((error: Error) => {
-        // TODO dev logging, errors should not be shown to user
-        console.error(error);
-      });
-  }, []);
+    response && setAppData(response.data);
+  }, [response]);
 
   return isLoading || Object.values(appData).length < 1 ? (
-    <DnaLoader />
+    <Loader />
   ) : (
     <>
       <ApplicationHeader data={appData} />

--- a/components/pages/Applications/types.ts
+++ b/components/pages/Applications/types.ts
@@ -1,3 +1,4 @@
+import { Method } from 'axios';
 import { SortingRule } from 'react-table';
 import { ApplicationState } from 'components/ApplicationProgressBar/types';
 
@@ -19,6 +20,9 @@ export type SortedChangeFunction = (
 ) => void;
 
 export type ApplicationsRequestData = {
+  appId?: string;
+  data?: any;
+  method?: Method;
   page?: number;
   pageSize?: number;
   sort?: ApplicationsSort[];

--- a/global/hooks/useApplicationsAPI.tsx
+++ b/global/hooks/useApplicationsAPI.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { AxiosError, AxiosResponse } from 'axios';
+import { AxiosError, AxiosResponse, Method } from 'axios';
 import { ApplicationsRequestData } from '../../components/pages/Applications/types';
 import useAuthContext from './useAuthContext';
 import {
@@ -12,14 +12,14 @@ import {
 import { API } from 'global/constants/externalPaths';
 
 const useApplicationsAPI = ({
+  appId = '',
+  data,
+  method,
   page = DEFAULT_PAGE,
   pageSize = DEFAULT_PAGE_SIZE,
   sort = DEFAULT_SORT,
   states = [],
-}: // method
-// id
-// ...etc
-ApplicationsRequestData) => {
+}: ApplicationsRequestData = {}) => {
   const [response, setResponse] = useState<AxiosResponse | undefined>(undefined);
   const [error, setError] = useState<AxiosError | undefined>(undefined);
 
@@ -28,13 +28,15 @@ ApplicationsRequestData) => {
   useEffect(() => {
     if (token && !isLoading) {
       fetchWithAuth({
+        data,
+        method,
         params: {
           page,
           pageSize,
           sort: stringifySort(sort),
           states: stringifyStates(states),
         },
-        url: API.APPLICATIONS,
+        url: `${API.APPLICATIONS}/${appId}`,
       })
         .then((res: any) => {
           setResponse(res);

--- a/global/hooks/useAuthContext.tsx
+++ b/global/hooks/useAuthContext.tsx
@@ -74,6 +74,7 @@ export const AuthProvider = ({
   const cancelTokenSource = axios.CancelToken.source();
   const cancelFetchWithAuth = cancelTokenSource.cancel;
   const fetchWithAuth = ({
+    data,
     params = {},
     headers = {},
     method = 'GET' as Method,
@@ -91,6 +92,7 @@ export const AuthProvider = ({
     }
 
     const config: AxiosRequestConfig = {
+      ...(!['DELETE', 'GET'].includes(method) && { data }),
       baseURL: NEXT_PUBLIC_DAC_API_ROOT,
       cancelToken: cancelTokenSource.token,
       headers: {


### PR DESCRIPTION
using the Application header as a test subject, @samrichca pointed out the hook was missing the capacity to pass data body and methods other than GET. This PR addresses that, as well as covering some technical debt I had introduced in the header (which account for the extra changes).