### PR TITLE
✨ 175 - cover signature pages

### DIFF
--- a/components/pages/Applications/ApplicationForm/Header/Actions.tsx
+++ b/components/pages/Applications/ApplicationForm/Header/Actions.tsx
@@ -21,7 +21,9 @@ import StaticITAgreements from '../../PDF/StaticITAgreements';
 import StaticDataAccessAgreement from '../../PDF/StaticDataAccessAgreement';
 import StaticAppendices from '../../PDF/StaticAppendices';
 import { getFormattedDate } from '../../Dashboard/Applications/InProgress/helpers';
-import { FILE_DATE } from '../../Dashboard/Applications/InProgress/constants';
+import { FILE_DATE_FORMAT } from '../../Dashboard/Applications/InProgress/constants';
+import Cover from '../../PDF/Cover';
+import Signatures from '../../PDF/Signatures';
 
 const HeaderActions = ({ appId }: { appId: string }): ReactElement => {
   const theme: UikitTheme = useTheme();
@@ -31,6 +33,8 @@ const HeaderActions = ({ appId }: { appId: string }): ReactElement => {
   const generatePDFDocument = async (data: any) => {
     const blob = await pdf(
       <Document>
+        {/* Cover is PDF only */}
+        <Cover data={data} />
         <StaticIntroduction isPdf data={data} />
         <StaticApplicant isPdf data={data} />
         <StaticRepresentative isPdf data={data} />
@@ -40,10 +44,12 @@ const HeaderActions = ({ appId }: { appId: string }): ReactElement => {
         <StaticITAgreements isPdf data={data} />
         <StaticDataAccessAgreement isPdf data={data} />
         <StaticAppendices isPdf data={data} />
+        {/* Signatures is PDF only */}
+        <Signatures data={data} />
       </Document>,
     ).toBlob();
 
-    const dateCreated = getFormattedDate(Date.now(), FILE_DATE);
+    const dateCreated = getFormattedDate(Date.now(), FILE_DATE_FORMAT);
     saveAs(blob, `${data.appId}-${dateCreated}`);
   };
 

--- a/components/pages/Applications/Dashboard/Applications/InProgress/constants.ts
+++ b/components/pages/Applications/Dashboard/Applications/InProgress/constants.ts
@@ -1,3 +1,4 @@
 export const SIMPLE_DATE_FORMAT = 'MMMM. dd, yyyy';
-export const TIME_AND_DATE_FORMAT = "MMMM. dd, yyyy 'at' h:m aaaa";
-export const FILE_DATE = 'yyyyMMdd';
+export const TIME_AND_DATE_FORMAT = "MMMM. dd, yyyy 'at' h:mm aaaa";
+export const FILE_DATE_FORMAT = 'yyyyMMdd';
+export const TIME_DAY_AND_DATE_FORMAT = "EEE. MMM. dd, yyyy 'at' h:mm aaaa";

--- a/components/pages/Applications/PDF/Cover.tsx
+++ b/components/pages/Applications/PDF/Cover.tsx
@@ -1,0 +1,82 @@
+import React from 'react';
+import defaultTheme from '@icgc-argo/uikit/theme/defaultTheme';
+
+import { View, Text, StyleSheet } from '@react-pdf/renderer';
+import PDFLayout from './PdfLayout';
+import PDFIcgcDaco from './icons/PdfIcgcDaco';
+import { PDFText, PDFTitle } from './common';
+import VerticalTable from './VerticalTable';
+import { ApplicationData } from '../types';
+import { getFormattedDate } from '../Dashboard/Applications/InProgress/helpers';
+import { TIME_DAY_AND_DATE_FORMAT } from '../Dashboard/Applications/InProgress/constants';
+
+const styles = StyleSheet.create({
+  tableValue: {
+    color: defaultTheme.colors.secondary,
+    fontWeight: 'semibold',
+  },
+  container: {
+    display: 'flex',
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  title: {
+    marginTop: '50pt',
+  },
+  subtitle: {
+    marginTop: '20pt',
+  },
+  table: {
+    padding: '10pt 5pt 10pt 5pt',
+    width: '460pt',
+  },
+});
+
+const Cover = ({ data }: { data?: ApplicationData }) => {
+  const piData = [
+    {
+      fieldName: 'Daco Application #',
+      fieldValue: <Text style={styles.tableValue}>{data?.appId}</Text>,
+    },
+    {
+      fieldName: 'Principal Investigator',
+      fieldValue: (
+        <Text style={styles.tableValue}>{data?.sections.applicant.info.displayName}</Text>
+      ),
+    },
+    {
+      fieldName: 'Institution',
+      fieldValue: (
+        <Text style={styles.tableValue}>{data?.sections.applicant.info.primaryAffiliation}</Text>
+      ),
+    },
+    {
+      fieldName: 'Document rendered on',
+      fieldValue: (
+        <Text style={styles.tableValue}>
+          {getFormattedDate(Date.now(), TIME_DAY_AND_DATE_FORMAT)}
+        </Text>
+      ),
+    },
+  ];
+
+  return (
+    <PDFLayout appId={data?.appId} state={data?.state} applicant={data?.sections?.applicant.info}>
+      <View style={styles.container}>
+        <PDFIcgcDaco />
+        <PDFText style={styles.subtitle}>ICGC DATA ACCESS COMPLIANCE OFFICE</PDFText>
+        <PDFTitle style={styles.title}>Application for Access to ICGC Controlled Data</PDFTitle>
+        <VerticalTable
+          style={styles.table}
+          headerCellWidth={40}
+          useExternalBorders
+          useInternalBorders={false}
+          data={piData}
+        />
+      </View>
+    </PDFLayout>
+  );
+};
+
+export default Cover;

--- a/components/pages/Applications/PDF/Cover.tsx
+++ b/components/pages/Applications/PDF/Cover.tsx
@@ -9,6 +9,7 @@ import VerticalTable from './VerticalTable';
 import { ApplicationData } from '../types';
 import { getFormattedDate } from '../Dashboard/Applications/InProgress/helpers';
 import { TIME_DAY_AND_DATE_FORMAT } from '../Dashboard/Applications/InProgress/constants';
+import { FieldAccessor } from './types';
 
 const styles = StyleSheet.create({
   tableValue: {
@@ -48,7 +49,9 @@ const Cover = ({ data }: { data?: ApplicationData }) => {
     {
       fieldName: 'Institution',
       fieldValue: (
-        <Text style={styles.tableValue}>{data?.sections.applicant.info.primaryAffiliation}</Text>
+        <Text style={styles.tableValue}>
+          {data?.sections.applicant.info[FieldAccessor.PRIMARY_AFFILIATION]}
+        </Text>
       ),
     },
     {

--- a/components/pages/Applications/PDF/Cover.tsx
+++ b/components/pages/Applications/PDF/Cover.tsx
@@ -4,7 +4,7 @@ import defaultTheme from '@icgc-argo/uikit/theme/defaultTheme';
 import { View, Text, StyleSheet } from '@react-pdf/renderer';
 import PDFLayout from './PdfLayout';
 import PDFIcgcDaco from './icons/PdfIcgcDaco';
-import { PDFText, PDFTitle } from './common';
+import { getDisplayName, PDFText, PDFTitle } from './common';
 import VerticalTable from './VerticalTable';
 import { ApplicationData } from '../types';
 import { getFormattedDate } from '../Dashboard/Applications/InProgress/helpers';
@@ -42,7 +42,7 @@ const Cover = ({ data }: { data?: ApplicationData }) => {
     {
       fieldName: 'Principal Investigator',
       fieldValue: (
-        <Text style={styles.tableValue}>{data?.sections.applicant.info.displayName}</Text>
+        <Text style={styles.tableValue}>{getDisplayName(data?.sections.applicant.info)}</Text>
       ),
     },
     {

--- a/components/pages/Applications/PDF/PdfLayout.tsx
+++ b/components/pages/Applications/PDF/PdfLayout.tsx
@@ -5,6 +5,7 @@ import { ApplicationState } from 'components/ApplicationProgressBar/types';
 import { ReactNode } from 'react';
 import { PDFLink } from './common';
 import { getConfig } from 'global/config';
+import { ApplicationDataByField } from '../types';
 
 const styles = StyleSheet.create({
   page: {
@@ -59,10 +60,7 @@ const PDFLayout = ({
   state = 'draft',
   children,
 }: {
-  applicant?: {
-    displayName: string;
-    title: string;
-  };
+  applicant?: Partial<ApplicationDataByField>;
   appId?: string;
   state?: string;
   children: ReactNode;

--- a/components/pages/Applications/PDF/PdfLayout.tsx
+++ b/components/pages/Applications/PDF/PdfLayout.tsx
@@ -3,6 +3,8 @@ import { Page, View, Text, StyleSheet } from '@react-pdf/renderer';
 import defaultTheme from '@icgc-argo/uikit/theme/defaultTheme';
 import { ApplicationState } from 'components/ApplicationProgressBar/types';
 import { ReactNode } from 'react';
+import { PDFLink } from './common';
+import { getConfig } from 'global/config';
 
 const styles = StyleSheet.create({
   page: {
@@ -75,7 +77,9 @@ const PDFLayout = ({
       <View style={styles.section}>{children}</View>
       <View style={styles.footer} fixed>
         <Text>
-          {appId} created by {displayName} using ICGC-DACO (https://www.daco.icgc.org)
+          {/* TODO: get daco url from config/constant value */}
+          {appId} created by {displayName} using{' '}
+          <PDFLink href={'https://daco.icgc.org'}>ICGC-DACO</PDFLink>
         </Text>
       </View>
       {isDraftState && <Watermark />}

--- a/components/pages/Applications/PDF/Signatures.tsx
+++ b/components/pages/Applications/PDF/Signatures.tsx
@@ -1,18 +1,66 @@
 import React from 'react';
 import defaultTheme from '@icgc-argo/uikit/theme/defaultTheme';
 
-import { View, Text, StyleSheet } from '@react-pdf/renderer';
+import { View, StyleSheet } from '@react-pdf/renderer';
 import PDFLayout from './PdfLayout';
-import { PDFLink, PDFParagraph, PDFText, PDFTitle, SectionTitle } from './common';
+import { PdfFormFields, PDFLink, PDFParagraph, PDFText, PDFTitle, SectionTitle } from './common';
 import VerticalTable from './VerticalTable';
 import { ApplicationData } from '../types';
 import { ADOBE_ACROBAT_LINK, DOCUSIGN_LINK } from 'global/constants/externalPaths';
+import { FieldAccessor, PdfFieldName, PdfFormField } from './types';
+import { styles as commonStyles } from './common';
 
-// const styles = StyleSheet.create({
-//     par
-// })
+const styles = StyleSheet.create({
+  table: {
+    marginBottom: '25pt',
+    borderBottom: `1pt solid ${defaultTheme.colors.grey_1}`,
+  },
+});
 
+const Signature = () => (
+  <View
+    style={{
+      display: 'flex',
+      flexDirection: 'row',
+      width: '100%',
+      alignItems: 'center',
+      height: '30pt',
+    }}
+  >
+    <PDFText style={{ fontWeight: 'semibold', marginRight: '10pt' }}>Signature:</PDFText>
+    <View
+      style={{
+        borderTop: `2pt solid ${defaultTheme.colors.black}`,
+        marginTop: '2pt',
+        width: '90%',
+      }}
+    />
+  </View>
+);
+
+// data needs to be ApplicationData type. needs to be fixed here and in other verticalTable usages
 const Signatures = ({ data }: { data?: ApplicationData }) => {
+  const signerFields = [
+    PdfFormFields.NAME,
+    PdfFormFields.PRIMARY_AFFILIATION,
+    PdfFormFields.POSITION_TITLE,
+  ];
+
+  const applicantData = signerFields.map((field: any) => ({
+    fieldName: field.fieldName,
+    fieldValue: data?.sections.applicant.info[field.fieldKey],
+  }));
+
+  const representativeData = signerFields.map((field) => ({
+    fieldName: field.fieldName,
+    fieldValue: data?.sections.representative.info[field.fieldKey],
+  }));
+
+  const dacoData = ['Name', 'Title', 'Date of Approval'].map((fieldName: string) => ({
+    fieldName,
+    fieldValue: '',
+  }));
+
   return (
     <PDFLayout appId={data?.appId} state={data?.state} applicant={data?.sections?.applicant.info}>
       <PDFTitle>Signatures</PDFTitle>
@@ -37,14 +85,39 @@ const Signatures = ({ data }: { data?: ApplicationData }) => {
         </PDFText>
         <PDFText count={2}>Upload the signed application to your online DACO application.</PDFText>
       </View>
-      <View>
+      <View
+        style={{
+          borderTop: `1pt solid ${defaultTheme.colors.grey_1}`,
+          marginTop: '15pt',
+          marginBottom: '15pt',
+          paddingTop: '5pt',
+        }}
+      >
         <SectionTitle>APPLICANT AUTHORIZATION</SectionTitle>
+        <VerticalTable style={styles.table} useInternalBorders data={applicantData} />
+        <Signature />
       </View>
-      <View>
+      <View
+        style={{
+          borderTop: `1pt solid ${defaultTheme.colors.grey_1}`,
+          marginTop: '15pt',
+          marginBottom: '25pt',
+          paddingTop: '5pt',
+        }}
+      >
         <SectionTitle>INSTITUTIONAL REPRESENTATIVE AUTHORIZATION</SectionTitle>
+        <VerticalTable style={styles.table} useInternalBorders data={representativeData} />
+        <Signature />
       </View>
-      <View>
-        <PDFParagraph>Reserved for the ICGC Data Access Compliance Office (ICGC DACO)</PDFParagraph>
+      <View
+        style={{ border: `2pt solid ${defaultTheme.colors.black}`, padding: '10pt' }}
+        wrap={false}
+      >
+        <PDFParagraph style={{ ...commonStyles.highlighted, fontWeight: 'semibold' }}>
+          Reserved for the ICGC Data Access Compliance Office (ICGC DACO)
+        </PDFParagraph>
+        <VerticalTable useInternalBorders data={dacoData} style={styles.table} />
+        <Signature />
       </View>
     </PDFLayout>
   );

--- a/components/pages/Applications/PDF/Signatures.tsx
+++ b/components/pages/Applications/PDF/Signatures.tsx
@@ -45,7 +45,6 @@ const Signature = () => (
   </View>
 );
 
-// data needs to be ApplicationData type. needs to be fixed here and in other verticalTable usages
 const Signatures = ({ data }: { data?: ApplicationData }) => {
   const signerFields = [
     PdfFormFields.NAME,

--- a/components/pages/Applications/PDF/Signatures.tsx
+++ b/components/pages/Applications/PDF/Signatures.tsx
@@ -1,13 +1,20 @@
 import React from 'react';
 import defaultTheme from '@icgc-argo/uikit/theme/defaultTheme';
-
 import { View, StyleSheet } from '@react-pdf/renderer';
+
 import PDFLayout from './PdfLayout';
-import { PdfFormFields, PDFLink, PDFParagraph, PDFText, PDFTitle, SectionTitle } from './common';
+import {
+  getFieldValue,
+  PdfFormFields,
+  PDFLink,
+  PDFParagraph,
+  PDFText,
+  PDFTitle,
+  SectionTitle,
+} from './common';
 import VerticalTable from './VerticalTable';
 import { ApplicationData } from '../types';
 import { ADOBE_ACROBAT_LINK, DOCUSIGN_LINK } from 'global/constants/externalPaths';
-import { FieldAccessor, PdfFieldName, PdfFormField } from './types';
 import { styles as commonStyles } from './common';
 
 const styles = StyleSheet.create({
@@ -46,14 +53,14 @@ const Signatures = ({ data }: { data?: ApplicationData }) => {
     PdfFormFields.POSITION_TITLE,
   ];
 
-  const applicantData = signerFields.map((field: any) => ({
+  const applicantData = signerFields.map((field) => ({
     fieldName: field.fieldName,
-    fieldValue: data?.sections.applicant.info[field.fieldKey],
+    fieldValue: getFieldValue(data?.sections.applicant.info, field.fieldKey),
   }));
 
   const representativeData = signerFields.map((field) => ({
     fieldName: field.fieldName,
-    fieldValue: data?.sections.representative.info[field.fieldKey],
+    fieldValue: getFieldValue(data?.sections.representative.info, field.fieldKey),
   }));
 
   const dacoData = ['Name', 'Title', 'Date of Approval'].map((fieldName: string) => ({

--- a/components/pages/Applications/PDF/Signatures.tsx
+++ b/components/pages/Applications/PDF/Signatures.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import defaultTheme from '@icgc-argo/uikit/theme/defaultTheme';
+
+import { View, Text, StyleSheet } from '@react-pdf/renderer';
+import PDFLayout from './PdfLayout';
+import { PDFLink, PDFParagraph, PDFText, PDFTitle, SectionTitle } from './common';
+import VerticalTable from './VerticalTable';
+import { ApplicationData } from '../types';
+import { ADOBE_ACROBAT_LINK, DOCUSIGN_LINK } from 'global/constants/externalPaths';
+
+// const styles = StyleSheet.create({
+//     par
+// })
+
+const Signatures = ({ data }: { data?: ApplicationData }) => {
+  return (
+    <PDFLayout appId={data?.appId} state={data?.state} applicant={data?.sections?.applicant.info}>
+      <PDFTitle>Signatures</PDFTitle>
+      <View>
+        <PDFParagraph>
+          The final step involves adding the proper signatures to authorize this application. Please
+          do the following:
+        </PDFParagraph>
+        <PDFText count={1} style={{ fontWeight: 'semibold', marginBottom: '2pt' }}>
+          You must include BOTH the Principal Investigator and the Institutional Representative
+          signatures in order for your application to be reviewed.
+        </PDFText>
+
+        <PDFText style={{ marginLeft: '20pt' }}>
+          a) You can print this page, collect the written signatures, scan the signed page and add
+          it back to the finalized application pdf.
+        </PDFText>
+        <PDFText style={{ marginLeft: '20pt', marginBottom: '10pt' }}>
+          b) Or you can add the proper signatures using electronic methods, such as{' '}
+          <PDFLink href={DOCUSIGN_LINK}>DocuSign</PDFLink> or{' '}
+          <PDFLink href={ADOBE_ACROBAT_LINK}>AdobeSign</PDFLink>.
+        </PDFText>
+        <PDFText count={2}>Upload the signed application to your online DACO application.</PDFText>
+      </View>
+      <View>
+        <SectionTitle>APPLICANT AUTHORIZATION</SectionTitle>
+      </View>
+      <View>
+        <SectionTitle>INSTITUTIONAL REPRESENTATIVE AUTHORIZATION</SectionTitle>
+      </View>
+      <View>
+        <PDFParagraph>Reserved for the ICGC Data Access Compliance Office (ICGC DACO)</PDFParagraph>
+      </View>
+    </PDFLayout>
+  );
+};
+
+export default Signatures;

--- a/components/pages/Applications/PDF/StaticApplicant.tsx
+++ b/components/pages/Applications/PDF/StaticApplicant.tsx
@@ -3,13 +3,13 @@ import defaultTheme from '@icgc-argo/uikit/theme/defaultTheme';
 import { View } from '@react-pdf/renderer';
 
 import RequiredFieldsMessage from '../ApplicationForm/Forms/RequiredFieldsMessage';
-import { getStaticComponents, PdfFormFields, SectionTitle } from './common';
+import { getFieldValue, getStaticComponents, PdfFormFields, SectionTitle } from './common';
 import FORM_TEXT from './textConstants';
 import VerticalTable from './VerticalTable';
 import { getStreetAddress } from './common';
 import { ApplicationData } from '../types';
 
-const PdfApplicantFormData = ({ data }: { data: any }) => {
+const PdfApplicantFormData = ({ data }: { data?: ApplicationData }) => {
   const applicantFields = [
     PdfFormFields.NAME,
     PdfFormFields.PRIMARY_AFFILIATION,
@@ -19,22 +19,22 @@ const PdfApplicantFormData = ({ data }: { data: any }) => {
     PdfFormFields.POSITION_TITLE,
   ];
   const applicantData = applicantFields.map(({ fieldName, fieldKey }) => {
-    return { fieldName, fieldValue: data.sections.applicant.info[fieldKey] };
+    return { fieldName, fieldValue: getFieldValue(data?.sections.applicant.info, fieldKey) };
   });
 
-  const address = data.sections.applicant.address;
+  const address = data?.sections.applicant.address;
   const addressData = [
     {
       fieldName: 'Mailing Address',
-      fieldValue: getStreetAddress(address.streetAddress, address.building),
+      fieldValue: getStreetAddress(address?.streetAddress, address?.building),
     },
     {
-      fieldValue: address.cityAndProvince,
+      fieldValue: address?.cityAndProvince,
     },
     {
-      fieldValue: address.country,
+      fieldValue: address?.country,
     },
-    { fieldValue: address.postalCode },
+    { fieldValue: address?.postalCode },
   ];
 
   return (
@@ -69,7 +69,7 @@ const StaticApplicant = ({ isPdf = false, data }: { isPdf?: boolean; data?: Appl
     <ContainerComponent
       appId={data?.appId}
       state={data?.state}
-      applicant={data?.sections?.applicant.info}
+      applicant={data?.sections.applicant.info}
     >
       <TitleComponent>A. Applicant Information (Principal Investigator)</TitleComponent>
       <SectionComponent>

--- a/components/pages/Applications/PDF/StaticCollaborators.tsx
+++ b/components/pages/Applications/PDF/StaticCollaborators.tsx
@@ -1,7 +1,13 @@
 import React from 'react';
 import defaultTheme from '@icgc-argo/uikit/theme/defaultTheme';
 
-import { getStaticComponents, PdfFormFields, PDFParagraph, SectionTitle } from './common';
+import {
+  getFieldValue,
+  getStaticComponents,
+  PdfFormFields,
+  PDFParagraph,
+  SectionTitle,
+} from './common';
 import FORM_TEXT from './textConstants';
 import { View } from '@react-pdf/renderer';
 import VerticalTable from './VerticalTable';
@@ -44,7 +50,7 @@ const PdfCollaboratorsFormData = ({ data }: { data?: ApplicationData }) => {
                 key={person.id}
                 data={personnelFields.map((field) => ({
                   fieldName: field.fieldName,
-                  fieldValue: person.info[field.fieldKey],
+                  fieldValue: getFieldValue(person.info, field.fieldKey),
                 }))}
                 useExternalBorders
               />
@@ -73,7 +79,7 @@ const PdfCollaboratorsFormData = ({ data }: { data?: ApplicationData }) => {
                 <VerticalTable
                   data={studentFields.map((field) => ({
                     fieldName: field.fieldName,
-                    fieldValue: student.info[field.fieldKey],
+                    fieldValue: getFieldValue(student.info, field.fieldKey),
                   }))}
                   useExternalBorders
                 />

--- a/components/pages/Applications/PDF/StaticProjectInfo.tsx
+++ b/components/pages/Applications/PDF/StaticProjectInfo.tsx
@@ -13,7 +13,7 @@ import {
 import FORM_TEXT from './textConstants';
 import { View } from '@react-pdf/renderer';
 import VerticalTable, { DataCell } from './VerticalTable';
-import { PdfFieldName } from './types';
+import { FieldAccessor, PdfFieldName } from './types';
 import { ApplicationData, ApplicationDataByField } from '../types';
 
 const BasicInfo = ({ data }: { data?: Partial<ApplicationDataByField> }) => {
@@ -290,7 +290,6 @@ const StaticProjectInfo = ({
     TitleComponent,
   } = getStaticComponents(isPdf);
 
-  // TODO: need to add text for textareas from data
   return (
     <ContainerComponent
       appId={data?.appId}
@@ -315,24 +314,26 @@ const StaticProjectInfo = ({
             {FORM_TEXT.project_info.inputLabel.background}
           </PDFParagraph>
           <BackgroundBubble isPdf />
-          <PDFTextArea>{data?.sections.projectInfo.background}</PDFTextArea>
+          <PDFTextArea>{data?.sections.projectInfo[FieldAccessor.BACKGROUND]}</PDFTextArea>
           <PDFParagraph style={{ fontWeight: 600 }}>
             {FORM_TEXT.project_info.inputLabel.aims}
           </PDFParagraph>
           <AimsBubble isPdf />
-          <PDFTextArea>{data?.sections.projectInfo.aims}</PDFTextArea>
+          <PDFTextArea>{data?.sections.projectInfo[FieldAccessor.AIMS]}</PDFTextArea>
           <PDFParagraph style={{ fontWeight: 600 }}>
             {FORM_TEXT.project_info.inputLabel.dataUse}
           </PDFParagraph>
           <DataUseBubble isPdf />
-          <PDFTextArea>{data?.sections.projectInfo.methodology}</PDFTextArea>
+          <PDFTextArea>{data?.sections.projectInfo[FieldAccessor.METHODOLOGY]}</PDFTextArea>
           <StaticLaySummary isPdf />
           <PDFParagraph style={{ fontWeight: 600 }}>
             {FORM_TEXT.project_info.inputLabel.laySummary}
           </PDFParagraph>
           <LaySummaryBubble isPdf />
-          <PDFTextArea>{data?.sections.projectInfo.summary}</PDFTextArea>
-          <PdfPublicationsFormData data={data?.sections.projectInfo.publicationsURLs as string[]} />
+          <PDFTextArea>{data?.sections.projectInfo[FieldAccessor.SUMMARY]}</PDFTextArea>
+          <PdfPublicationsFormData
+            data={data?.sections.projectInfo[FieldAccessor.PUBLICATIONS_URL] as string[]}
+          />
         </View>
       )}
     </ContainerComponent>

--- a/components/pages/Applications/PDF/StaticProjectInfo.tsx
+++ b/components/pages/Applications/PDF/StaticProjectInfo.tsx
@@ -6,19 +6,17 @@ import {
   getStaticComponents,
   PdfFormFields,
   PDFParagraph,
-  PDFText,
   PDFTextArea,
-  Section,
   SectionTitle,
   styles,
 } from './common';
 import FORM_TEXT from './textConstants';
-import { Text, View } from '@react-pdf/renderer';
-import VerticalTable from './VerticalTable';
+import { View } from '@react-pdf/renderer';
+import VerticalTable, { DataCell } from './VerticalTable';
 import { PdfFieldName } from './types';
-import { ApplicationData } from '../types';
+import { ApplicationData, ApplicationDataByField } from '../types';
 
-const BasicInfo = ({ data }: { data: any }) => {
+const BasicInfo = ({ data }: { data?: Partial<ApplicationDataByField> }) => {
   const infoFields = [PdfFormFields.PROJECT_TITLE, PdfFormFields.PROJECT_WEBSITE];
   return (
     <View
@@ -30,10 +28,12 @@ const BasicInfo = ({ data }: { data: any }) => {
     >
       <SectionTitle>{FORM_TEXT.project_info.basic_info}</SectionTitle>
       <VerticalTable
-        data={infoFields.map((field) => ({
-          fieldName: field.fieldName,
-          fieldValue: data[field.fieldKey],
-        }))}
+        data={
+          infoFields.map((field) => ({
+            fieldName: field.fieldName,
+            fieldValue: data ? data[field.fieldKey] : '',
+          })) as DataCell[]
+        }
       />
     </View>
   );
@@ -171,7 +171,7 @@ export const LaySummaryBubble = ({ isPdf = false }: { isPdf?: boolean }) => {
   );
 };
 
-const PdfPublicationsFormData = ({ data }: { data: any }) => {
+const PdfPublicationsFormData = ({ data = [] }: { data?: string[] }) => {
   return (
     <View>
       <StaticPublications isPdf />
@@ -331,9 +331,8 @@ const StaticProjectInfo = ({
             {FORM_TEXT.project_info.inputLabel.laySummary}
           </PDFParagraph>
           <LaySummaryBubble isPdf />
-          {/* TODO: add lay summary from data */}
-          <PDFTextArea>{'Lay summary data not available'}</PDFTextArea>
-          <PdfPublicationsFormData data={data?.sections.projectInfo.publicationsURLs} />
+          <PDFTextArea>{data?.sections.projectInfo.summary}</PDFTextArea>
+          <PdfPublicationsFormData data={data?.sections.projectInfo.publicationsURLs as string[]} />
         </View>
       )}
     </ContainerComponent>

--- a/components/pages/Applications/PDF/StaticRepresentative.tsx
+++ b/components/pages/Applications/PDF/StaticRepresentative.tsx
@@ -2,13 +2,19 @@ import React from 'react';
 import defaultTheme from '@icgc-argo/uikit/theme/defaultTheme';
 
 import RequiredFieldsMessage from '../ApplicationForm/Forms/RequiredFieldsMessage';
-import { getStaticComponents, getStreetAddress, PdfFormFields, SectionTitle } from './common';
+import {
+  getFieldValue,
+  getStaticComponents,
+  getStreetAddress,
+  PdfFormFields,
+  SectionTitle,
+} from './common';
 import FORM_TEXT from './textConstants';
 import { View } from '@react-pdf/renderer';
 import VerticalTable from './VerticalTable';
 import { ApplicationData } from '../types';
 
-const PdfRepFormData = ({ data }: { data: any }) => {
+const PdfRepFormData = ({ data }: { data?: ApplicationData }) => {
   const repFields = [
     PdfFormFields.NAME,
     PdfFormFields.PRIMARY_AFFILIATION,
@@ -22,15 +28,15 @@ const PdfRepFormData = ({ data }: { data: any }) => {
   const addressData = [
     {
       fieldName: 'Mailing Address',
-      fieldValue: getStreetAddress(address.streetAddress, address.building),
+      fieldValue: getStreetAddress(address?.streetAddress, address?.building),
     },
     {
-      fieldValue: address.cityAndProvince,
+      fieldValue: address?.cityAndProvince,
     },
     {
-      fieldValue: address.country,
+      fieldValue: address?.country,
     },
-    { fieldValue: address.postalCode },
+    { fieldValue: address?.postalCode },
   ];
 
   return (
@@ -40,7 +46,7 @@ const PdfRepFormData = ({ data }: { data: any }) => {
         <VerticalTable
           data={repFields.map((field) => ({
             fieldName: field.fieldName,
-            fieldValue: data?.sections.representative.info[field.fieldKey],
+            fieldValue: getFieldValue(data?.sections.representative.info, field.fieldKey),
           }))}
         />
       </View>

--- a/components/pages/Applications/PDF/VerticalTable.tsx
+++ b/components/pages/Applications/PDF/VerticalTable.tsx
@@ -1,6 +1,7 @@
 import React, { ReactElement } from 'react';
 import { Text, View, StyleSheet } from '@react-pdf/renderer';
 import defaultTheme from '@icgc-argo/uikit/theme/defaultTheme';
+import { PdfFieldName } from './types';
 
 const styles = StyleSheet.create({
   tableStyle: {
@@ -71,8 +72,8 @@ const TableRow = ({
   );
 };
 
-interface DataCell {
-  fieldName?: string;
+export interface DataCell {
+  fieldName?: PdfFieldName | string;
   fieldValue?: string | React.ReactElement;
 }
 
@@ -83,6 +84,7 @@ const VerticalTable = ({
   headerCellWidth = 30,
   valueCellWidth = 70,
   style = {},
+  wrap = false,
 }: {
   data: DataCell[];
   useInternalBorders?: boolean;
@@ -90,9 +92,11 @@ const VerticalTable = ({
   headerCellWidth?: number;
   valueCellWidth?: number;
   style?: object;
+  wrap?: boolean;
 }) => {
   return (
     <View
+      wrap={wrap}
       style={{
         ...styles.tableStyle,
         ...(useExternalBorders && borderedTableStyles.table),

--- a/components/pages/Applications/PDF/VerticalTable.tsx
+++ b/components/pages/Applications/PDF/VerticalTable.tsx
@@ -55,7 +55,7 @@ const TableRow = ({
         }}
       >
         <Text style={{ ...styles.tableCellStyle, ...styles.tableCellHeaderStyle }}>
-          {headerName}
+          {headerName ? `${headerName}:` : ''}
         </Text>
       </View>
 

--- a/components/pages/Applications/PDF/VerticalTable.tsx
+++ b/components/pages/Applications/PDF/VerticalTable.tsx
@@ -14,6 +14,7 @@ const styles = StyleSheet.create({
   },
   tableCellHeaderStyle: {
     fontWeight: 'semibold',
+    marginRight: '10pt',
   },
   tableCellStyle: {
     padding: '6pt 0',
@@ -38,7 +39,7 @@ const TableRow = ({
   useExternalBorders,
 }: {
   headerName?: string;
-  value?: string;
+  value?: string | React.ReactElement;
   headerCellWidth: number;
   valueCellWidth: number;
   hasBottomBorder: boolean;
@@ -72,28 +73,40 @@ const TableRow = ({
 
 interface DataCell {
   fieldName?: string;
-  fieldValue?: string;
+  fieldValue?: string | React.ReactElement;
 }
 
 const VerticalTable = ({
   data,
   useInternalBorders = true,
   useExternalBorders = false,
+  headerCellWidth = 30,
+  valueCellWidth = 70,
+  style = {},
 }: {
   data: DataCell[];
   useInternalBorders?: boolean;
   useExternalBorders?: boolean;
+  headerCellWidth?: number;
+  valueCellWidth?: number;
+  style?: object;
 }) => {
   return (
-    <View style={{ ...styles.tableStyle, ...(useExternalBorders && borderedTableStyles.table) }}>
+    <View
+      style={{
+        ...styles.tableStyle,
+        ...(useExternalBorders && borderedTableStyles.table),
+        ...style,
+      }}
+    >
       {data.map((cell: DataCell, i: number) => {
         return (
           <TableRow
             key={`${cell.fieldName}-${i}`}
             headerName={cell.fieldName}
             value={cell.fieldValue}
-            headerCellWidth={30}
-            valueCellWidth={70}
+            headerCellWidth={headerCellWidth}
+            valueCellWidth={valueCellWidth}
             hasBottomBorder={useInternalBorders && i !== data.length - 1}
             useExternalBorders={useExternalBorders}
           />

--- a/components/pages/Applications/PDF/common.tsx
+++ b/components/pages/Applications/PDF/common.tsx
@@ -1,5 +1,5 @@
 import React, { ReactNode } from 'react';
-import { Text, View, Font, StyleSheet, Svg } from '@react-pdf/renderer';
+import { Text, View, Font, StyleSheet } from '@react-pdf/renderer';
 import defaultTheme from '@icgc-argo/uikit/theme/defaultTheme';
 import Typography from '@icgc-argo/uikit/Typography';
 import Link from '@icgc-argo/uikit/Link';
@@ -270,6 +270,37 @@ export const getStaticComponents = (isPdf: boolean) => {
       };
 };
 
+export const getStreetAddress = (street?: string, building?: string) => {
+  let streetAddress = [];
+  street?.length && streetAddress.push(street);
+  building?.length && streetAddress.push(building);
+  return streetAddress.join(', ');
+};
+
+export const getDisplayName = (info: any) => {
+  let name: string[] = [];
+  const nameAccessors = [
+    FieldAccessor.TITLE,
+    FieldAccessor.FIRST_NAME,
+    FieldAccessor.MIDDLE_NAME,
+    FieldAccessor.LAST_NAME,
+    FieldAccessor.SUFFIX,
+  ];
+  nameAccessors.map((accessor) => {
+    if (info[accessor]) {
+      name.push(info[accessor]);
+    }
+  });
+  return name.join(' ');
+};
+
+export const getFieldValue = (info: any, accessor: FieldAccessor) => {
+  if (accessor === FieldAccessor.DISPLAY_NAME) {
+    return getDisplayName(info);
+  }
+  return info[accessor];
+};
+
 export const PdfFormFields: PdfFormField = {
   [PdfField.NAME]: { fieldName: PdfFieldName.NAME, fieldKey: FieldAccessor.DISPLAY_NAME },
   [PdfField.PRIMARY_AFFILIATION]: {
@@ -304,11 +335,4 @@ export const PdfFormFields: PdfFormField = {
     fieldName: PdfFieldName.PROJECT_WEBSITE,
     fieldKey: FieldAccessor.PROJECT_WEBSITE,
   },
-};
-
-export const getStreetAddress = (street: string, building: string) => {
-  let streetAddress = [];
-  street?.length && streetAddress.push(street);
-  building?.length && streetAddress.push(building);
-  return streetAddress.join(', ');
 };

--- a/components/pages/Applications/PDF/types.ts
+++ b/components/pages/Applications/PDF/types.ts
@@ -7,6 +7,17 @@ export enum FieldAccessor {
   POSITION_TITLE = 'positionTitle',
   PROJECT_TITLE = 'title',
   PROJECT_WEBSITE = 'website',
+  FIRST_NAME = 'firstName',
+  LAST_NAME = 'lastName',
+  MIDDLE_NAME = 'middleName',
+  SUFFIX = 'suffix',
+  TITLE = 'title',
+  PUBLICATIONS_URL = 'publicationsURLs',
+  BACKGROUND = 'background',
+  METHODOLOGY = 'methodology',
+  AIMS = 'aims',
+  WEBSITE = 'website',
+  SUMMARY = 'summary',
 }
 
 export enum PdfField {

--- a/components/pages/Applications/types.ts
+++ b/components/pages/Applications/types.ts
@@ -1,5 +1,6 @@
 import { Method } from 'axios';
 import { SortingRule } from 'react-table';
+import { FieldAccessor } from './PDF/types';
 
 export type ApplicationRecord = {
   appId: string;
@@ -73,26 +74,29 @@ export type ApplicationsResponseItem = {
   state: string;
 };
 
+export type ApplicationDataByField = {
+  [k in FieldAccessor]: string | string[];
+};
+
+export type IndividualInfo = {
+  [FieldAccessor.FIRST_NAME]: string;
+  [FieldAccessor.GOOGLE_EMAIL]: string;
+  [FieldAccessor.DISPLAY_NAME]: string;
+  [FieldAccessor.INSTITUTIONAL_EMAIL]: string;
+  [FieldAccessor.LAST_NAME]: string;
+  [FieldAccessor.MIDDLE_NAME]: string;
+  [FieldAccessor.POSITION_TITLE]: string;
+  [FieldAccessor.PRIMARY_AFFILIATION]: string;
+  [FieldAccessor.SUFFIX]: string;
+  [FieldAccessor.TITLE]: string;
+};
+
 interface Address {
   building: string;
   cityAndProvince: string;
   country: string;
   postalCode: string;
   streetAddress: string;
-}
-
-interface IndividualInfo {
-  firstName: string;
-  googleEmail: string;
-  displayName: string;
-  institutionEmail: string;
-  institutionWebsite: string;
-  lastName: string;
-  middleName: string;
-  positionTitle: string;
-  primaryAffiliation: string;
-  suffix: string;
-  title: string;
 }
 
 interface Terms {
@@ -108,6 +112,16 @@ export interface ApprovalDoc {
   name: 'string';
   objectId: 'string';
   uploadedAtUtc: 'string';
+}
+
+export interface ProjectInfo {
+  [FieldAccessor.PUBLICATIONS_URL]: string[];
+  [FieldAccessor.BACKGROUND]: string;
+  [FieldAccessor.METHODOLOGY]: string;
+  [FieldAccessor.AIMS]: string;
+  [FieldAccessor.WEBSITE]: string;
+  [FieldAccessor.TITLE]: string;
+  [FieldAccessor.SUMMARY]: string;
 }
 
 export enum ITAgreementEnum {
@@ -155,15 +169,6 @@ interface Representative {
 
 interface Collaborators {
   list: Collaborator[];
-}
-
-interface ProjectInfo {
-  publicationsURLs: string[];
-  background: string;
-  methodology: string;
-  aims: string;
-  website: string;
-  title: string;
 }
 
 interface EthicsLetter {

--- a/global/constants/externalPaths.ts
+++ b/global/constants/externalPaths.ts
@@ -23,6 +23,8 @@ export const GLASGOW_UNI_LINK = 'https://www.gla.ac.uk/';
 export const OICR_LINK = 'https://www.oicr.on.ca/';
 export const ICGC_DCC_LINK = 'https://dcc.icgc.org/';
 export const ICGC_PCAWG_LINK = urlJoin(ICGC_DCC_LINK, 'pcawg');
+export const DOCUSIGN_LINK = 'https://www.docusign.ca';
+export const ADOBE_ACROBAT_LINK = 'https://acrobat.adobe.com/us/en/sign.html';
 
 // API
 export const API = {


### PR DESCRIPTION
Adds Cover and Signatures page, these are for PDF only.
Fixes minute format in `TIME_AND_DATE_FORMAT`
Defaults VerticalTable to `wrap=false` to prevent weird double render of some rows
Makes VerticalTable header width customisable
VerticalTable values can now be strings or elements
Adds some missing typing
Fixes individual's display name to include `title` and `suffix`
Adds `projectInfo.summary` from api data