### PR TITLE
189 - add focus touch to select-one fields

### DIFF
--- a/components/pages/Applications/ApplicationForm/Forms/Applicant.tsx
+++ b/components/pages/Applications/ApplicationForm/Forms/Applicant.tsx
@@ -46,6 +46,7 @@ const Applicant = ({
               aria-label="Title"
               id="info_title"
               onBlur={validateFieldTouched}
+              onFocus={validateFieldTouched}
               eventOnChange={validateFieldTouched}
               options={transformToSelectOptions(honorificsList)}
               value={localState.info_title?.value}

--- a/components/pages/Applications/ApplicationForm/Forms/Representative.tsx
+++ b/components/pages/Applications/ApplicationForm/Forms/Representative.tsx
@@ -50,6 +50,7 @@ const Representative = ({
               aria-label="Title"
               id="info_title"
               onBlur={validateFieldTouched}
+              onFocus={validateFieldTouched}
               eventOnChange={validateFieldTouched}
               options={transformToSelectOptions(honorificsList)}
               value={localState.info_title?.value}

--- a/components/pages/Applications/ApplicationForm/Forms/validations/index.ts
+++ b/components/pages/Applications/ApplicationForm/Forms/validations/index.ts
@@ -464,6 +464,11 @@ export const useLocalValidation = (
           break;
         }
 
+        case 'focus': {
+          ['select-one'].includes(fieldType) && setFieldTouched((prev) => new Set(prev.add(field)));
+          break;
+        }
+
         default: {
           console.info('unhandled Field event', event);
           break;


### PR DESCRIPTION
The select fields (e.g. Applicant and Representative `title`) are not saving changes on the first interaction, as the `blur` logic persists only data for fields that had been `touched` before the change.
This logic touches these upon focusing on them, so changes can be saved once the user moves away from them.