### PR TITLE
🐛 Rep address can use sameAsApplicant value

### DIFF
--- a/components/pages/Applications/PDF/StaticRepresentative.tsx
+++ b/components/pages/Applications/PDF/StaticRepresentative.tsx
@@ -22,9 +22,12 @@ const PdfRepFormData = ({ data }: { data?: ApplicationData }) => {
     PdfFormFields.POSITION_TITLE,
   ];
 
+  const address = data?.sections.representative.addressSameAsApplicant
+    ? data.sections.applicant.address
+    : data?.sections.representative.address;
+
   // there may be a nicer way to handle the mailing address, but not going to worry about it right now
   // it's only used in 2 places
-  const address = data?.sections.representative.address;
   const addressData = [
     {
       fieldName: 'Mailing Address',

--- a/components/pages/Applications/types.ts
+++ b/components/pages/Applications/types.ts
@@ -163,8 +163,9 @@ interface Collaborator {
 }
 
 interface Representative {
-  address: Address;
+  address?: Address;
   info: IndividualInfo;
+  addressSameAsApplicant: boolean;
 }
 
 interface Collaborators {


### PR DESCRIPTION
Representative address on pdf will use applicant address when `addressSameAsApplicant` is true