### PR TITLE
54 - validate Primary Affiliation matches

### DIFF
--- a/components/pages/Applications/ApplicationForm/Forms/Collaborators/TableComponent.tsx
+++ b/components/pages/Applications/ApplicationForm/Forms/Collaborators/TableComponent.tsx
@@ -1,8 +1,10 @@
 import { RefObject } from 'react';
-import Table from '@icgc-argo/uikit/Table';
+import { RowInfo } from 'react-table';
 import { css } from '@emotion/core';
 
+import { UikitTheme } from '@icgc-argo/uikit/index';
 import Icon from '@icgc-argo/uikit/Icon';
+import Table from '@icgc-argo/uikit/Table';
 import { useTheme } from '@icgc-argo/uikit/ThemeProvider';
 
 import { ApplicationState, CollaboratorType } from 'components/pages/Applications/types';
@@ -16,7 +18,7 @@ const Actions = ({
   removeCollaborator: () => void;
   applicationState: ApplicationState;
 }) => {
-  const theme = useTheme();
+  const theme: UikitTheme = useTheme();
 
   return (
     <div
@@ -55,60 +57,71 @@ const TableComponent = ({
   data: [];
   handleActions: (action: 'edit' | 'remove', collaboratorId: string) => () => void;
   applicationState: ApplicationState;
-}) => (
-  <Table
-    css={css`
-      margin-top: 9px;
-    `}
-    showPagination={false}
-    defaultSorted={[{ id: 'positionTitle', desc: false }]}
-    columns={[
-      {
-        accessor: 'type',
-        Cell: ({ value }: { value: CollaboratorType }) =>
-          `Authorized ${value.charAt(0).toUpperCase()}${value.slice(1)}`,
-        Header: 'Collaborator Type',
-        id: 'positionTitle',
-        width: 150,
-      },
-      {
-        accessor: 'info.firstName',
-        Header: 'First Name',
-      },
-      {
-        accessor: 'info.lastName',
-        Header: 'Last Name',
-      },
-      {
-        accessor: 'info.institutionEmail',
-        Header: 'Institutional Email',
-        width: 170,
-      },
-      {
-        accessor: 'info.googleEmail',
-        Header: 'Google Email',
-        width: 170,
-      },
-      {
-        accessor: 'id',
-        Cell: ({ value }: { value: string }) => {
-          return (
-            <Actions
-              editCollaborator={handleActions('edit', value)}
-              removeCollaborator={handleActions('remove', value)}
-              applicationState={applicationState}
-            />
-          );
+}) => {
+  const theme: UikitTheme = useTheme();
+
+  return (
+    <Table
+      columns={[
+        {
+          accessor: 'type',
+          Cell: ({ value }: { value: CollaboratorType }) =>
+            `Authorized ${value.charAt(0).toUpperCase()}${value.slice(1)}`,
+          Header: 'Collaborator Type',
+          id: 'positionTitle',
+          width: 150,
         },
-        Header: 'Actions',
-        width: 90,
-      },
-    ]}
-    data={data}
-    parentRef={containerRef}
-    stripped
-    withOutsideBorder
-  />
-);
+        {
+          accessor: 'info.firstName',
+          Header: 'First Name',
+        },
+        {
+          accessor: 'info.lastName',
+          Header: 'Last Name',
+        },
+        {
+          accessor: 'info.institutionEmail',
+          Header: 'Institutional Email',
+          width: 170,
+        },
+        {
+          accessor: 'info.googleEmail',
+          Header: 'Google Email',
+          width: 170,
+        },
+        {
+          accessor: 'id',
+          Cell: ({ value }: { value: string }) => {
+            return (
+              <Actions
+                editCollaborator={handleActions('edit', value)}
+                removeCollaborator={handleActions('remove', value)}
+                applicationState={applicationState}
+              />
+            );
+          },
+          Header: 'Actions',
+          width: 90,
+        },
+      ]}
+      css={css`
+        margin-top: 9px;
+      `}
+      data={data}
+      defaultSorted={[{ id: 'positionTitle', desc: false }]}
+      getTrProps={(state: any, rowInfo?: RowInfo) => ({
+        ...(rowInfo?.original?.meta?.errorsList?.length > 0 && {
+          style: {
+            background: theme.colors.error_4,
+          },
+        }),
+      })}
+      parentRef={containerRef}
+      showPagination={false}
+      stripped
+      withOutsideBorder
+    />
+  );
+};
 
 export default TableComponent;

--- a/components/pages/Applications/ApplicationForm/Forms/Collaborators/index.tsx
+++ b/components/pages/Applications/ApplicationForm/Forms/Collaborators/index.tsx
@@ -70,7 +70,7 @@ const Collaborators = ({
     validateFieldTouched({
       // faking event values to keep scope limited
       target: {
-        id: 'list--all--clearModal',
+        id: 'list----clearModal',
         tagName: 'MODAL',
         type: 'clearModal',
       },
@@ -165,7 +165,7 @@ const Collaborators = ({
     validateFieldTouched({
       // faking event values to keep scope limited
       target: {
-        id: 'list--all--feedModal',
+        id: 'list----feedModal',
         tagName: 'MODAL',
         type: 'feedModal',
         value: localState.list.value.find(({ id }: Collaborator) => collaboratorId === id),

--- a/components/pages/Applications/ApplicationForm/Forms/types.ts
+++ b/components/pages/Applications/ApplicationForm/Forms/types.ts
@@ -126,7 +126,6 @@ export type FormSectionValidationState_Collaborators =
           info_primaryAffiliation: { value: string };
           info_suffix: { value: string };
           info_title: { value: string };
-          info_website: { value: string };
           type: { value: string };
         },
       ];
@@ -238,7 +237,7 @@ export type FormValidationActionTypes =
   | 'updating';
 
 export type FormValidationAction = {
-  error?: string[];
+  error?: any;
   field: string;
   overall: FormSectionOverallState;
   section: FormSectionNames;

--- a/components/pages/Applications/ApplicationForm/Forms/validations/helpers.ts
+++ b/components/pages/Applications/ApplicationForm/Forms/validations/helpers.ts
@@ -261,3 +261,15 @@ export const uniquePublicationURLs = {
     });
   },
 };
+
+export const checkMatchingPrimaryAffiliation = (
+  value: string,
+  applicantPrimaryAffiliation: string,
+) =>
+  value &&
+  applicantPrimaryAffiliation &&
+  value.trim() !== applicantPrimaryAffiliation && {
+    error: [
+      `Primary Affiliation must be the same as the Applicant: ${applicantPrimaryAffiliation}`,
+    ],
+  };

--- a/components/pages/Applications/ApplicationForm/Forms/validations/index.ts
+++ b/components/pages/Applications/ApplicationForm/Forms/validations/index.ts
@@ -24,6 +24,7 @@ import {
 import {
   getFieldDataFromEvent,
   getValueByFieldTypeToPublish,
+  checkMatchingPrimaryAffiliation,
   schemaValidator,
   sectionFieldsSeeder,
 } from './helpers';
@@ -86,7 +87,8 @@ export const validationReducer = (
               ...formState.sections[action.section]?.fields,
               [fieldName]: {
                 ...formState.sections[action.section]?.fields?.[fieldName],
-                ...(formState.sections[action.section]?.fields?.[fieldName]?.meta?.shape === 'modal'
+                ...(formState.sections[action.section]?.fields?.[fieldName]?.meta?.shape ===
+                  'modal' && fieldIndex
                   ? {
                       innerType: {
                         ...formState.sections[action.section]?.fields?.[fieldName].innerType,
@@ -145,6 +147,8 @@ export const validationReducer = (
                   ).reduce((acc, innerField) => {
                     const [fieldNamePrefix, fieldNameSuffix] = innerField[0].split('_');
 
+                    const error = action.error?.[innerField[0]];
+
                     return {
                       ...acc,
                       [innerField[0]]:
@@ -152,6 +156,7 @@ export const validationReducer = (
                           ? omit(innerField[1] as FormFieldType, ['error', 'value'])
                           : {
                               ...(innerField[1] as FormFieldType),
+                              ...error,
                               value: fieldNameSuffix
                                 ? action.value[fieldNamePrefix][fieldNameSuffix]
                                 : action.value[innerField[0]],
@@ -175,7 +180,7 @@ export const validationReducer = (
             ...formState.sections[action.section],
             meta: {
               ...formState.sections[action.section].meta,
-              validated: true,
+              validated: action.value,
             },
           },
         },
@@ -229,57 +234,118 @@ export const validator: FormSectionValidatorFunction_Main =
   (formState, dispatch, apiFetcher) =>
   (origin, validateSection) =>
   async (field, value, shouldPersistResults) => {
+    const applicantPrimaryAffiliation =
+      formState.sections.applicant.fields.info_primaryAffiliation.value;
+    const validatingApplicant = origin === 'applicant';
+
     if (validateSection) {
-      const sectionErrorsListFromBackEnd = formState.sections[origin].meta.errorsList || [];
-      if (sectionErrorsListFromBackEnd.length > 0) {
-        // WIP: marks the section as validated, so this is only done only once after seeding.
-        dispatch({
-          section: origin,
-          type: 'overall',
-        });
+      dispatch({
+        section: origin,
+        type: 'overall',
+        value: true,
+      });
 
-        Object.entries(formState.sections[origin]?.fields as object).forEach(
-          async ([field, data]) => {
-            if (data.value) {
-              const [fieldName, fieldIndex, fieldOverride] = field.split('--');
+      Object.entries(formState.sections[origin]?.fields as object).forEach(
+        async ([field, data]) => {
+          if (data.value) {
+            const validatingPrimaryAffiliation = field.includes('info_primaryAffiliation');
+            const [fieldName, fieldIndex, fieldOverride] = field.split('--');
 
-              const { error } = await schemaValidator(
-                yup.reach(
-                  combinedSchema[origin],
-                  fieldIndex && fieldOverride !== 'overall'
-                    ? `${fieldName}.${fieldIndex}`
-                    : fieldName,
-                ),
-                data.value,
-              );
+            const { error } = await schemaValidator(
+              yup.reach(
+                combinedSchema[origin],
+                fieldIndex && fieldOverride !== 'overall'
+                  ? `${fieldName}.${fieldIndex}`
+                  : fieldName,
+              ),
+              data.meta?.shape === 'modal'
+                ? data.value.map((modalItem: any) =>
+                    Object.entries(data.innerType?.fields).reduce((acc, innerField) => {
+                      const [fieldNamePrefix, fieldNameSuffix] = innerField[0].split('_');
 
-              const results = {
-                field,
-                section: origin,
-                type: data.type,
-                value: data.value,
-                ...(error && { error }),
-              } as FormValidationAction;
+                      return {
+                        ...acc,
+                        [innerField[0]]: fieldNameSuffix
+                          ? modalItem[fieldNamePrefix][fieldNameSuffix]
+                          : modalItem[innerField[0]],
+                      };
+                    }, {}),
+                  )
+                : data.value,
+            );
 
-              dispatch(results);
-            }
-          },
-        );
-        // });
-      }
-      // return results;
+            const results = {
+              field,
+              section: origin,
+              type: data.type,
+              value: data.value,
+              ...(error
+                ? { error }
+                : !validatingApplicant &&
+                  validatingPrimaryAffiliation &&
+                  checkMatchingPrimaryAffiliation(data.value, applicantPrimaryAffiliation)),
+            } as FormValidationAction;
+
+            dispatch(results);
+          }
+        },
+      );
     } else if (field) {
       const [fieldName, fieldIndex, fieldOverride] = field.split('--');
       const fieldIsArray = !Number.isNaN(Number(fieldIndex));
 
       if (fieldOverride?.includes('Modal')) {
+        const error =
+          value &&
+          Object.keys(formState.sections[origin].fields[fieldName].innerType?.fields).reduce(
+            (acc, innerField) => {
+              const validatingPrimaryAffiliation = innerField.includes('primaryAffiliation');
+              const [fieldNamePrefix, fieldNameSuffix] = innerField.split('_');
+              const innerValue = fieldNameSuffix
+                ? value[fieldNamePrefix][fieldNameSuffix]
+                : value[innerField];
+
+              const { error } = schemaValidator(
+                yup.reach(combinedSchema[origin], `${fieldName}.${innerField}`),
+                innerValue,
+              );
+
+              const validationResult = error
+                ? { error }
+                : !validatingApplicant &&
+                  validatingPrimaryAffiliation &&
+                  checkMatchingPrimaryAffiliation(innerValue, applicantPrimaryAffiliation);
+
+              return {
+                ...acc,
+                ...(validationResult && { [innerField]: validationResult }),
+              };
+            },
+            {},
+          );
+
         dispatch({
           field: fieldName,
           section: origin,
           type: fieldOverride as FormValidationActionTypes,
           value,
+          error,
         });
       } else {
+        const validatingPrimaryAffiliation = field.includes('info_primaryAffiliation');
+
+        if (
+          validatingApplicant &&
+          validatingPrimaryAffiliation &&
+          checkMatchingPrimaryAffiliation(value, applicantPrimaryAffiliation)
+        ) {
+          dispatch({
+            section: 'representative',
+            type: 'overall',
+            value: false,
+          });
+        }
+
         const { error } = fieldOverride
           ? { error: null } // TODO: this validation will be handled in ticket #138
           : await schemaValidator(
@@ -289,15 +355,15 @@ export const validator: FormSectionValidatorFunction_Main =
                   ? `${fieldName}.${fieldIndex}`
                   : fieldName,
               ),
-              fieldOverride === 'overall'
-                ? Object.values<FormFieldType>(formState.sections[origin]?.fields[fieldName]?.value)
-                    .filter(({ value }) => value !== null)
-                    .map(({ value }) => value)
-                : value,
+              value,
             );
 
         const nextValue = {
-          ...(error && { error }),
+          ...(error
+            ? { error }
+            : !validatingApplicant &&
+              validatingPrimaryAffiliation &&
+              checkMatchingPrimaryAffiliation(value, applicantPrimaryAffiliation)),
           value,
         };
 

--- a/components/pages/Applications/ApplicationForm/Forms/validations/schemas.ts
+++ b/components/pages/Applications/ApplicationForm/Forms/validations/schemas.ts
@@ -94,17 +94,10 @@ export const collaboratorSchema = yup.object().shape({
           .required(),
         info_lastName: yup.string().default('').required(),
         info_middleName: yup.string().default(''),
-        info_primaryAffiliation: yup.string().default('').required(),
         info_positionTitle: yup.string().default('').required(),
+        info_primaryAffiliation: yup.string().default('').required(),
         info_suffix: yup.string().default(''),
         info_title: yup.string().default(''),
-        info_website: yup
-          .string()
-          .default('')
-          .url(
-            'Please enter a valid url. Must begin with http:// or https://, for example, https://platform.icgc-argo.org/.',
-          )
-          .required(),
         type: yup.string().oneOf(['personnel', 'student']).required(),
       }),
     )


### PR DESCRIPTION
An extra bit of useful complication for the validation monster.
Basically, when dealing with a `primaryAffiliation` field, compare it with the one in the applicant section, if available.
If the one in applicant changes, revalidate the others (representative and collaborators, currently).