### PR TITLE
54 - ensure applicant affiliation change triggers validation

### DIFF
--- a/components/pages/Applications/ApplicationForm/Forms/validations/index.ts
+++ b/components/pages/Applications/ApplicationForm/Forms/validations/index.ts
@@ -337,7 +337,7 @@ export const validator: FormSectionValidatorFunction_Main =
         if (
           validatingApplicant &&
           validatingPrimaryAffiliation &&
-          checkMatchingPrimaryAffiliation(value, applicantPrimaryAffiliation)
+          applicantPrimaryAffiliation !== value
         ) {
           dispatch({
             section: 'representative',


### PR DESCRIPTION
I had the wrong check for this trigger.
This change checks for any changes (even for `''`), rather than checking if there's a match.