### PR TITLE
214 - enable add/edit collaborator button when modal is valid

### DIFF
--- a/components/pages/Applications/ApplicationForm/Forms/Collaborators/index.tsx
+++ b/components/pages/Applications/ApplicationForm/Forms/Collaborators/index.tsx
@@ -101,9 +101,9 @@ const Collaborators = ({
         ...dataAcc,
         [prefix]: suffix
           ? {
-            ...dataAcc[prefix],
-            [suffix]: fieldData.value,
-          }
+              ...dataAcc[prefix],
+              [suffix]: fieldData.value,
+            }
           : fieldData.value,
       };
     }, {} as Record<string, any>);
@@ -195,7 +195,12 @@ const Collaborators = ({
     const newModalFields = getInternalFieldSchema(localState.list);
 
     collaboratorCount === newCollaboratorCount || setCollaboratorCount(newCollaboratorCount);
-    setModalHasErrors(Object.values(newModalFields).some((field: any) => field?.error?.length > 0));
+    setModalHasErrors(
+      Object.values(newModalFields).some((field: any) => field?.error?.length > 0) ||
+        !Object.entries(newModalFields)
+          .filter(([fieldName, fieldData]) => fieldName !== 'type' && isRequired(fieldData))
+          .every(([fieldName, fieldData]) => fieldData.value),
+    );
     setModalFields(newModalFields);
   }, [localState]);
 
@@ -496,7 +501,11 @@ const Collaborators = ({
 
                   <DoubleFieldRow helpText="This must match the applicant’s primary affiliation exactly.">
                     <FormControl
-                      error={!!modalFields.info_primaryAffiliation?.error}
+                      error={
+                        // additional logic to quietly ensure validation is applied before allowing save
+                        !!modalFields.info_primaryAffiliation?.error?.filter((e: string) => e)
+                          .length
+                      }
                       required={isRequired(modalFields.info_primaryAffiliation)}
                     >
                       <InputLabel htmlFor="info_primaryAffiliation">Primary Affiliation</InputLabel>

--- a/components/pages/Applications/ApplicationForm/Forms/Collaborators/index.tsx
+++ b/components/pages/Applications/ApplicationForm/Forms/Collaborators/index.tsx
@@ -402,6 +402,7 @@ const Collaborators = ({
                         disabled={isSectionDisabled}
                         id="list--info_title"
                         onBlur={validateFieldTouched}
+                        onFocus={validateFieldTouched}
                         eventOnChange={validateFieldTouched}
                         options={transformToSelectOptions(honorificsList)}
                         value={modalFields.info_title?.value}

--- a/components/pages/Applications/ApplicationForm/Forms/validations/index.ts
+++ b/components/pages/Applications/ApplicationForm/Forms/validations/index.ts
@@ -522,6 +522,7 @@ export const useLocalValidation = (
 
   const updateLocalState = useCallback(
     ({ error, field, value, type }: FormValidationAction) => {
+      const validatingPrimaryAffiliation = field.includes('info_primaryAffiliation');
       const [fieldName, fieldIndex, fieldOverride] = field.split('--');
       const currentSectionData = localState[sectionName];
       const currentSectionFields = currentSectionData?.fields;
@@ -553,7 +554,8 @@ export const useLocalValidation = (
                               [fieldIndex]: {
                                 ...currentField.innerType?.fields[fieldIndex],
                                 ...(value[fieldIndex] || { value }),
-                                error,
+                                // ensure affiliation validation is applied before allowing "save"
+                                error: validatingPrimaryAffiliation ? error || [''] : error,
                               },
                             },
                           },


### PR DESCRIPTION
adds logic to check all required fields in the modal have a value and ensure that the primary affiliation is valid, before enabling the magic button.

Bonus: fixes the `title` field