### PR TITLE
#298: add default blank option to select options

### DIFF
--- a/components/pages/Applications/ApplicationForm/Forms/validations/helpers.ts
+++ b/components/pages/Applications/ApplicationForm/Forms/validations/helpers.ts
@@ -239,11 +239,13 @@ export const transformContriesToValidationOptions = (
   countriesList: CountryNamesAndAbbreviations[],
 ) => countriesList.map(({ name }: CountryNamesAndAbbreviations) => name);
 
-export const transformToSelectOptions = (list: Array<string | number>) =>
-  list.map((value: string | number) => ({
+export const transformToSelectOptions = (list: Array<string | number>) => [
+  { content: '-- Select an option --', value: '' },
+  ...list.map((value: string | number) => ({
     content: value,
     value: value,
-  }));
+  })),
+];
 
 export const uniquePublicationURLs = {
   name: `uniquePublicationURLs`,


### PR DESCRIPTION
- changed the first option in select fields to 'select an option' with an empty string value
- empty string is the default for select fields (according to `schemas.ts`)