### PR TITLE
334 - ensure all text values are trimmed on input

### DIFF
--- a/components/pages/Applications/ApplicationForm/Forms/validations/helpers.ts
+++ b/components/pages/Applications/ApplicationForm/Forms/validations/helpers.ts
@@ -188,7 +188,7 @@ export const getValueByFieldTypeToPublish = (
     }
 
     case 'string':
-      return { [fieldName]: fieldNameInner ? { [fieldNameInner]: value.trim() } : value.trim() };
+      return { [fieldName]: fieldNameInner ? { [fieldNameInner]: value } : value };
 
     default:
       console.info('unable to get value at getValueByFieldTypeToPublish', field, type);

--- a/components/pages/Applications/ApplicationForm/Forms/validations/index.ts
+++ b/components/pages/Applications/ApplicationForm/Forms/validations/index.ts
@@ -639,7 +639,9 @@ export const useLocalValidation = (
                   ? storedFields[fieldName]?.value?.[fieldIndex]
                   : storedFields[fieldName]?.value);
 
-            const changes = await fieldValidator(field, value, shouldPersistData);
+            const trimmedValue = ['text'].includes(fieldType) && value.trim();
+
+            const changes = await fieldValidator(field, trimmedValue || value, shouldPersistData);
 
             changes && updateLocalState(changes);
           }


### PR DESCRIPTION
Moves the string trimming to the `on blur` stage of input from the save request preparation.

Also, ensures the cursor/prompt in input fields inside the modal windows stops jumping to the end of the field (like Ego-ui)