### PR TITLE
346 - show SOME section status notifications

### DIFF
--- a/components/pages/Applications/ApplicationForm/Forms/validations/index.ts
+++ b/components/pages/Applications/ApplicationForm/Forms/validations/index.ts
@@ -415,10 +415,19 @@ export const validator: FormSectionValidatorFunction_Main =
               },
             }).then(({ data, ...response } = {} as AxiosResponse<any>) => {
               data
-                ? dispatch({
+                ? (!['', SECTION_STATUS.INCOMPLETE, SECTION_STATUS.PRISTINE].includes(
+                    data.sections[origin].meta.status || '',
+                  ) &&
+                    dispatch({
+                      field: 'showOverall',
+                      section: origin,
+                      type: 'sectionOverall',
+                      value: true,
+                    }),
+                  dispatch({
                     type: 'updating',
                     value: data,
-                  })
+                  }))
                 : console.error(
                     'Something went wrong updating the application form',
                     response || 'no data in response',


### PR DESCRIPTION
Fine tuning the validation notifications, we're supposed to show section status changes while the user fills up the form, as long as the status is not "incomplete" (aka error), which is only to be shown if the user moves onto a new section (or leaves the app) before fulfilling the sections' requirements.