### PR TITLE
93 - improve typeahead behaviour

### DIFF
--- a/components/pages/Applications/ApplicationForm/Forms/Applicant.tsx
+++ b/components/pages/Applications/ApplicationForm/Forms/Applicant.tsx
@@ -264,6 +264,7 @@ const Applicant = ({
             onChange={validateFieldTouched}
             onBlur={validateFieldTouched}
             single
+            size="sm"
             value={localState.address_country?.value ? [localState.address_country?.value] : []}
           >
             {countriesList.map(({ name }) => (

--- a/components/pages/Applications/ApplicationForm/Forms/Applicant.tsx
+++ b/components/pages/Applications/ApplicationForm/Forms/Applicant.tsx
@@ -263,6 +263,7 @@ const Applicant = ({
             name="address_country"
             onChange={validateFieldTouched}
             onBlur={validateFieldTouched}
+            placeholder={false}
             single
             size="sm"
             value={localState.address_country?.value ? [localState.address_country?.value] : []}

--- a/components/pages/Applications/ApplicationForm/Forms/Representative.tsx
+++ b/components/pages/Applications/ApplicationForm/Forms/Representative.tsx
@@ -248,6 +248,7 @@ const Representative = ({
             name="address_country"
             onChange={validateFieldTouched}
             onBlur={validateFieldTouched}
+            placeholder={false}
             single
             size="sm"
             value={addressState.address_country?.value ? [addressState.address_country?.value] : []}

--- a/components/pages/Applications/ApplicationForm/Forms/Representative.tsx
+++ b/components/pages/Applications/ApplicationForm/Forms/Representative.tsx
@@ -249,6 +249,7 @@ const Representative = ({
             onChange={validateFieldTouched}
             onBlur={validateFieldTouched}
             single
+            size="sm"
             value={addressState.address_country?.value ? [addressState.address_country?.value] : []}
           >
             {countriesList.map(({ name }) => (

--- a/components/pages/Applications/ApplicationForm/Forms/validations/helpers.ts
+++ b/components/pages/Applications/ApplicationForm/Forms/validations/helpers.ts
@@ -187,8 +187,11 @@ export const getValueByFieldTypeToPublish = (
       return null;
     }
 
-    case 'string':
-      return { [fieldName]: fieldNameInner ? { [fieldNameInner]: value } : value };
+    case 'string': {
+      const newStr = value || '';
+
+      return { [fieldName]: fieldNameInner ? { [fieldNameInner]: newStr } : newStr };
+    }
 
     default:
       console.info('unable to get value at getValueByFieldTypeToPublish', field, type);

--- a/components/pages/Applications/ApplicationForm/Forms/validations/helpers.ts
+++ b/components/pages/Applications/ApplicationForm/Forms/validations/helpers.ts
@@ -188,9 +188,7 @@ export const getValueByFieldTypeToPublish = (
     }
 
     case 'string': {
-      const newStr = value || '';
-
-      return { [fieldName]: fieldNameInner ? { [fieldNameInner]: newStr } : newStr };
+      return { [fieldName]: fieldNameInner ? { [fieldNameInner]: value } : value };
     }
 
     default:

--- a/components/pages/Applications/ApplicationForm/Forms/validations/helpers.ts
+++ b/components/pages/Applications/ApplicationForm/Forms/validations/helpers.ts
@@ -284,7 +284,7 @@ export const transformContriesToSelectOptions = (countriesList: CountryNamesAndA
 
 export const transformContriesToValidationOptions = (
   countriesList: CountryNamesAndAbbreviations[],
-) => countriesList.map(({ name }: CountryNamesAndAbbreviations) => name);
+) => countriesList.map(({ name }: CountryNamesAndAbbreviations) => name).concat('');
 
 export const transformToSelectOptions = (list: Array<string | number>) => [
   { content: '-- Select an option --', value: ' ' },

--- a/components/pages/Applications/ApplicationForm/Forms/validations/index.ts
+++ b/components/pages/Applications/ApplicationForm/Forms/validations/index.ts
@@ -632,30 +632,28 @@ export const useLocalValidation = (
 
       switch (eventType) {
         case 'blur': {
-          const canBlur = !['address_country'].includes(fieldName);
+          const shouldPersistData =
+            !!fieldType &&
+            ['select-one', 'text', 'textarea'].includes(fieldType) &&
+            fieldsTouched.has(field) &&
+            value !==
+              (fieldIndex
+                ? storedFields[fieldName]?.value?.[fieldIndex]
+                : storedFields[fieldName]?.value);
 
-          if (canBlur) {
-            const shouldPersistData =
-              !!fieldType &&
-              ['select-one', 'text', 'textarea'].includes(fieldType) &&
-              fieldsTouched.has(field) &&
-              value !==
-                (fieldIndex
-                  ? storedFields[fieldName]?.value?.[fieldIndex]
-                  : storedFields[fieldName]?.value);
+          const valueIsText = ['select-one', 'text'].includes(fieldType);
 
-            const trimmedValue = ['text'].includes(fieldType) && value.trim();
+          const changes = await fieldValidator(
+            field,
+            valueIsText ? (value || '').trim() : value,
+            shouldPersistData,
+          );
 
-            const changes = await fieldValidator(field, trimmedValue || value, shouldPersistData);
-
-            changes && updateLocalState(changes);
-          }
+          changes && updateLocalState(changes);
           break;
         }
 
-        case 'change':
-        case 'mousedown':
-        case 'keydown': {
+        case 'change': {
           if ('text' === fieldType) {
             updateLocalState({
               field,

--- a/components/pages/Applications/ApplicationForm/Forms/validations/index.ts
+++ b/components/pages/Applications/ApplicationForm/Forms/validations/index.ts
@@ -632,11 +632,7 @@ export const useLocalValidation = (
 
       switch (eventType) {
         case 'blur': {
-          const canBlur = !(
-            ['text'].includes(fieldType) &&
-            ['address_country'].includes(fieldName) &&
-            localState[sectionName]?.fields[fieldName]?.value
-          );
+          const canBlur = !['address_country'].includes(fieldName);
 
           if (canBlur) {
             const shouldPersistData =
@@ -658,7 +654,8 @@ export const useLocalValidation = (
         }
 
         case 'change':
-        case 'mousedown': {
+        case 'mousedown':
+        case 'keydown': {
           if ('text' === fieldType) {
             updateLocalState({
               field,

--- a/components/pages/Applications/ApplicationForm/Forms/validations/index.ts
+++ b/components/pages/Applications/ApplicationForm/Forms/validations/index.ts
@@ -692,6 +692,11 @@ export const useLocalValidation = (
           break;
         }
 
+        case 'keydown': {
+          // do nothing, triggered by 'select-one' (e.g. country);
+          break;
+        }
+
         default: {
           console.info('unhandled Field event', event);
           break;

--- a/components/pages/Applications/ApplicationForm/Forms/validations/schemas.ts
+++ b/components/pages/Applications/ApplicationForm/Forms/validations/schemas.ts
@@ -3,6 +3,7 @@ import { countriesList } from '../constants';
 import { FormSectionNames } from '../types';
 import { transformContriesToValidationOptions, maxWords, uniquePublicationURLs } from './helpers';
 
+export const countryNameMsg = 'Please select a country from the list.';
 export const requiredMsg = 'Please fill out the required field.';
 export const textareaLimit = 200;
 
@@ -13,8 +14,7 @@ yup.setLocale({
   },
   string: {
     email: 'Please enter a valid email address.',
-    url:
-      'Please enter a valid url. Must begin with http:// or https://, for example, https://platform.icgc-argo.org/.',
+    url: 'Please enter a valid url. Must begin with http:// or https://, for example, https://platform.icgc-argo.org/.',
     min: '${label} must be at least ${min} characters.',
   },
   number: {
@@ -43,7 +43,7 @@ export const applicantSchema = yup.object().shape({
     .string()
     .default('')
     .trim()
-    .oneOf(transformContriesToValidationOptions(countriesList))
+    .oneOf(transformContriesToValidationOptions(countriesList), countryNameMsg)
     .required(),
   address_postalCode: yup.string().default('').trim().required(),
   address_streetAddress: yup.string().default('').trim().required(),
@@ -182,7 +182,7 @@ export const representativeSchema = yup.object().shape({
     .string()
     .default('')
     .trim()
-    .oneOf(transformContriesToValidationOptions(countriesList))
+    .oneOf(transformContriesToValidationOptions(countriesList), countryNameMsg)
     .required(),
   address_postalCode: yup.string().default('').trim().required(),
   address_streetAddress: yup.string().default('').trim().required(),

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@emotion/core": "^10.0.10",
         "@emotion/styled": "^10.0.11",
         "@icgc-argo/ego-token-utils": "^8.2.0",
-        "@icgc-argo/uikit": "^1.12.0",
+        "@icgc-argo/uikit": "^1.12.1",
         "@react-pdf/renderer": "^2.0.15",
         "axios": "^0.21.1",
         "babel-plugin-emotion": "^10.2.2",
@@ -1855,9 +1855,9 @@
       }
     },
     "node_modules/@icgc-argo/uikit": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/@icgc-argo/uikit/-/uikit-1.12.0.tgz",
-      "integrity": "sha512-85NfgrP9iHQDYOqGT+SVwKJxN+IZe8beiZCEDAtzhh+b3sf8u4cA5rhlyQ7xLrnrI4Qx6p9WKPuyoWwRI106ag==",
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/@icgc-argo/uikit/-/uikit-1.12.1.tgz",
+      "integrity": "sha512-N9hlOnFzgVJAtHhY8D+MeKTYk4kf13Bx763TtO4M+wSa5wfbTsrHXWmficS1ekT2geaI+XMdODV8BROO5bL9Gg==",
       "dependencies": {
         "@babel/runtime-corejs2": "^7.7.2",
         "@emotion/core": "^10.0.10",
@@ -21110,9 +21110,9 @@
       }
     },
     "@icgc-argo/uikit": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/@icgc-argo/uikit/-/uikit-1.12.0.tgz",
-      "integrity": "sha512-85NfgrP9iHQDYOqGT+SVwKJxN+IZe8beiZCEDAtzhh+b3sf8u4cA5rhlyQ7xLrnrI4Qx6p9WKPuyoWwRI106ag==",
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/@icgc-argo/uikit/-/uikit-1.12.1.tgz",
+      "integrity": "sha512-N9hlOnFzgVJAtHhY8D+MeKTYk4kf13Bx763TtO4M+wSa5wfbTsrHXWmficS1ekT2geaI+XMdODV8BROO5bL9Gg==",
       "requires": {
         "@babel/runtime-corejs2": "^7.7.2",
         "@emotion/core": "^10.0.10",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@emotion/core": "^10.0.10",
     "@emotion/styled": "^10.0.11",
     "@icgc-argo/ego-token-utils": "^8.2.0",
-    "@icgc-argo/uikit": "^1.12.0",
+    "@icgc-argo/uikit": "^1.12.1",
     "@react-pdf/renderer": "^2.0.15",
     "axios": "^0.21.1",
     "babel-plugin-emotion": "^10.2.2",


### PR DESCRIPTION
As per specification, the `multiselect` component now behaves more like a typeahead now (following the example set by HCMI).
Changes included in this PR (apart from updating the package version) include restoring the country field validations, and 