### PR TITLE
flash data successful submission banner

### DIFF
--- a/components/pages/Applications/ApplicationForm/Forms/Signature.tsx
+++ b/components/pages/Applications/ApplicationForm/Forms/Signature.tsx
@@ -37,7 +37,7 @@ import {
 } from './types';
 import { UPLOAD_DATE_FORMAT } from '../../Dashboard/Applications/InProgress/constants';
 import { getFormattedDate } from '../../Dashboard/Applications/InProgress/helpers';
-import { API } from 'global/constants';
+import { API, SUBMISSION_SUCCESS_CHECK } from 'global/constants';
 import { useAuthContext } from 'global/hooks';
 import Modal from '@icgc-argo/uikit/Modal';
 import { ModalPortal } from 'components/Root';
@@ -105,7 +105,8 @@ const Signature = ({
       url: urlJoin(API.APPLICATIONS, appId),
     })
       .then(() => {
-        router.reload();
+        localStorage.setItem(SUBMISSION_SUCCESS_CHECK, 'true');
+        router.push(`/applications/${appId}?section=terms`);
       })
       .catch((err: AxiosError) => {
         console.error('Failed to submit.', err);

--- a/components/pages/Applications/ApplicationForm/Forms/index.tsx
+++ b/components/pages/Applications/ApplicationForm/Forms/index.tsx
@@ -32,6 +32,8 @@ import { enabledSections, sectionSelector } from './helpers';
 import Outline from './Outline';
 import { FormSectionNames, FormSectionValidationTriggerReasons, FORM_STATES } from './types';
 import { useFormValidation } from './validations';
+import Notification from '@icgc-argo/uikit/notifications/Notification';
+import { SUBMISSION_SUCCESS_CHECK } from 'global/constants';
 
 type QueryType = {
   query: {
@@ -40,6 +42,17 @@ type QueryType = {
 };
 
 type SetLastUpdated = (lastUpdatedAtUtc: string) => void;
+
+const getActiveSection = (sectionFromQuery?: FormSectionNames): FormSectionNames => {
+  if (!sectionFromQuery) return sectionsOrder[0];
+  const isValidSectionFromQuery = sectionsOrder.includes(sectionFromQuery);
+
+  return isValidSectionFromQuery
+    ? sectionFromQuery
+    : ((sectionFromQuery &&
+        console.info('Section initially queried was not found', sectionFromQuery),
+      sectionsOrder[0]) as FormSectionNames);
+};
 
 const ApplicationFormsBase = ({
   appId = 'none',
@@ -51,14 +64,12 @@ const ApplicationFormsBase = ({
   const {
     query: { section: sectionFromQuery = '' as FormSectionNames },
   }: QueryType = useRouter();
-  const isValidSectionFromQuery = sectionsOrder.includes(sectionFromQuery);
-  const [selectedSection, setSelectedSection] = useState(
-    isValidSectionFromQuery
-      ? sectionFromQuery
-      : (sectionFromQuery &&
-        console.info('Section initially queried was not found', sectionFromQuery),
-        sectionsOrder[0] as FormSectionNames),
-  );
+  const [selectedSection, setSelectedSection] = useState(getActiveSection(sectionFromQuery));
+
+  useEffect(() => {
+    setSelectedSection(getActiveSection(sectionFromQuery));
+  }, [sectionFromQuery]);
+
   const { isLoading, formState, validateSection } = useFormValidation(appId);
   const theme: UikitTheme = useTheme();
 
@@ -95,13 +106,13 @@ const ApplicationFormsBase = ({
 
     selectedSection === 'collaborators'
       ? formState.sections[selectedSection]?.meta.showOverall ||
-      triggerSectionValidation('notShowingOverall', selectedSection)
+        triggerSectionValidation('notShowingOverall', selectedSection)
       : sectionsOrder.forEach(
-        (section) =>
-          // validates all other section that doen't already show overall status.
-          !(formState.sections[section]?.meta.showOverall || selectedSection === section) &&
-          triggerSectionValidation('notShowingOverall', section),
-      );
+          (section) =>
+            // validates all other section that doen't already show overall status.
+            !(formState.sections[section]?.meta.showOverall || selectedSection === section) &&
+            triggerSectionValidation('notShowingOverall', section),
+        );
   }, [formState.lastUpdatedAtUtc]);
 
   const sectionIndex = sectionsOrder.indexOf(selectedSection);
@@ -131,6 +142,21 @@ const ApplicationFormsBase = ({
 
   return (
     <ContentBody>
+      {JSON.parse(localStorage.getItem(SUBMISSION_SUCCESS_CHECK) || 'false') && (
+        <Notification
+          title="Your Application has been Submitted"
+          content="The ICGC DACO has been notified for review and you should hear back within ten business days regarding the status of your application."
+          interactionType="CLOSE"
+          variant="SUCCESS"
+          onInteraction={({ type }) => {
+            if (type === 'CLOSE') {
+              localStorage.setItem(SUBMISSION_SUCCESS_CHECK, 'false');
+              router.push(`/applications/${appId}?section=${selectedSection}`);
+            }
+          }}
+        />
+      )}
+
       <ContentBox
         css={css`
           box-sizing: border-box;

--- a/global/constants/index.ts
+++ b/global/constants/index.ts
@@ -30,5 +30,7 @@ export const DATE_RANGE_DISPLAY_FORMAT = 'Y-MM-dd';
 
 export const DATE_TEXT_FORMAT = 'MMM. dd, yyyy';
 
+export const SUBMISSION_SUCCESS_CHECK = 'daco.submission-success-check';
+
 export * from './externalPaths';
 export * from './internalPaths';

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -48,9 +48,11 @@ const App = ({
 
   // set up router event listeners
   useEffect(() => {
-    const handleRouteChange = (url, { shallow }) => {
-      console.log('xxx', url, shallow);
-      resetFlashData();
+    const handleRouteChange = (url: string) => {
+      // only reset if page has changed, not just queries
+      if (url.split('?')[0] !== window.location.pathname) {
+        resetFlashData();
+      }
     };
 
     router.events.on('routeChangeStart', handleRouteChange);

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -22,11 +22,15 @@ import { NextPageContext } from 'next';
 import { AppContext } from 'next/app';
 import Root from 'components/Root';
 import { PageConfigProps, PageWithConfig } from 'global/utils/pages/types';
-import { EGO_JWT_KEY } from 'global/constants';
+import { EGO_JWT_KEY, SUBMISSION_SUCCESS_CHECK } from 'global/constants';
 import { isValidJwt } from 'global/utils/egoTokenUtils';
-import Router from 'next/router';
+import Router, { useRouter } from 'next/router';
 import Maintenance from 'components/pages/Error/Maintenance';
 import { getConfig } from 'global/config';
+
+const resetFlashData = () => {
+  [SUBMISSION_SUCCESS_CHECK].forEach((key) => localStorage.setItem(key, ''));
+};
 
 const App = ({
   Component,
@@ -39,6 +43,22 @@ const App = ({
 }) => {
   const [initialJwt, setInitialJwt] = useState<string>('');
   const { NEXT_PUBLIC_MAINTENANCE_MODE_ON } = getConfig();
+
+  const router = useRouter();
+
+  // set up router event listeners
+  useEffect(() => {
+    const handleRouteChange = (url, { shallow }) => {
+      console.log('xxx', url, shallow);
+      resetFlashData();
+    };
+
+    router.events.on('routeChangeStart', handleRouteChange);
+
+    return () => {
+      router.events.off('routeChangeStart', handleRouteChange);
+    };
+  }, []);
 
   useEffect(() => {
     const egoJwt = localStorage.getItem(EGO_JWT_KEY) || '';


### PR DESCRIPTION
- add flash data, with reset on route change
- avoids adding more local state
- avoids ugly navigable urls eg. user navigates to `.../submissionSuccess=true`  with zero context