### PR TITLE
#440: update status text for revisions requested

### DIFF
--- a/components/pages/Applications/Dashboard/Applications/InProgress/helpers.ts
+++ b/components/pages/Applications/Dashboard/Applications/InProgress/helpers.ts
@@ -22,25 +22,34 @@ import { format as formatDate } from 'date-fns';
 import { DATE_TEXT_FORMAT } from 'global/constants';
 import { StatusDates } from '.';
 
-export const getStatusText = (state: ApplicationState, dates: StatusDates) => {
+export const getStatusText = (
+  state: ApplicationState,
+  dates: StatusDates,
+  revisionsRequested: boolean,
+) => {
   const formatStatusDate = (date: string) =>
     formatDate(new Date(date || dates.lastUpdatedAtUtc), DATE_TEXT_FORMAT);
+
+  const revisionsRequestedText = `Reopened for revisions on ${formatStatusDate(
+    dates.lastUpdatedAtUtc,
+  )}. Revision details were sent via email.`;
+  const createdOnText = `Created on ${formatStatusDate(dates.createdAtUtc)}.`;
+
   switch (state) {
     case ApplicationState.APPROVED:
       return `Approved on ${formatStatusDate(
         dates.approvedAtUtc,
       )}. You now have access to ICGC Controlled Data.`;
     case ApplicationState.SIGN_AND_SUBMIT:
+      return revisionsRequested ? revisionsRequestedText : createdOnText;
     case ApplicationState.DRAFT:
-      return `Created on ${formatStatusDate(dates.createdAtUtc)}.`;
+      return createdOnText;
     case ApplicationState.REVIEW:
       return `Submitted on ${formatStatusDate(
         dates.submittedAtUtc,
       )}. This application is locked for ICGC DACO review.`;
     case ApplicationState.REVISIONS_REQUESTED:
-      return `Reopened for revisions on ${formatStatusDate(
-        dates.lastUpdatedAtUtc,
-      )}. Revision details were sent via email.`;
+      return revisionsRequestedText;
     case ApplicationState.REJECTED:
       return `Rejected on ${formatStatusDate(
         dates.lastUpdatedAtUtc,

--- a/components/pages/Applications/Dashboard/Applications/InProgress/index.tsx
+++ b/components/pages/Applications/Dashboard/Applications/InProgress/index.tsx
@@ -51,6 +51,7 @@ const InProgress = ({ application }: { application: ApplicationsResponseItem }) 
     lastUpdatedAtUtc,
     closedAtUtc,
     approvedAtUtc,
+    revisionsRequested,
   } = application;
 
   const dates: StatusDates = {
@@ -69,7 +70,11 @@ const InProgress = ({ application }: { application: ApplicationsResponseItem }) 
       >{`Access Expired: ${getFormattedDate(closedAtUtc, DATE_TEXT_FORMAT)}`}</div>
     ) : null;
 
-  const statusError = [ApplicationState.REVISIONS_REQUESTED].includes(state as ApplicationState);
+  const statusError = revisionsRequested &&
+    [
+      ApplicationState.REVISIONS_REQUESTED,
+      ApplicationState.SIGN_AND_SUBMIT
+    ].includes(state as ApplicationState);
 
   return (
     <DashboardCard title={`Application: ${appId}`} subtitle={primaryAffiliation} info={expiryDate}>
@@ -98,7 +103,7 @@ const InProgress = ({ application }: { application: ApplicationsResponseItem }) 
                 color: ${statusError ? theme.colors.error : 'inherit'};
               `}
             >
-              {getStatusText(state as ApplicationState, dates)}
+              {getStatusText(state as ApplicationState, dates, revisionsRequested)}
             </span>
           </div>
           <div>

--- a/components/pages/Applications/types.ts
+++ b/components/pages/Applications/types.ts
@@ -95,6 +95,7 @@ export type ApplicationsResponseItem = {
   submittedAtUtc: string;
   closedAtUtc: string;
   approvedAtUtc: string;
+  revisionsRequested: boolean;
 };
 
 export type ApplicationDataByField = {


### PR DESCRIPTION
- applications in request revisions state already have red status text
- use the same text for applications in sign & submit state, if revisions were requested