### PR TITLE
🐛 29 - Allow spaces in search query

### DIFF
--- a/components/pages/Applications/ManageApplications/index.tsx
+++ b/components/pages/Applications/ManageApplications/index.tsx
@@ -126,7 +126,7 @@ const ManageApplications = (): ReactElement => {
     pageSize,
     sort,
     states: adminStatesAllowList,
-    query: debouncedSearchQuery,
+    query: trim(debouncedSearchQuery),
   });
   const { items = [] } = response?.data || {};
   const { pagesCount = 0, totalCount = 0 } = response?.data?.pagingInfo || {};
@@ -226,7 +226,7 @@ const ManageApplications = (): ReactElement => {
                       preset="search"
                       value={searchQuery}
                       onChange={(e) => {
-                        onSearchQueryChange(trim(e.target.value));
+                        onSearchQueryChange(e.target.value);
                       }}
                       css={css`
                         width: 200px;

--- a/global/hooks/useGetApplications.tsx
+++ b/global/hooks/useGetApplications.tsx
@@ -59,7 +59,7 @@ const useGetApplications = ({
                 pageSize,
                 sort: stringifySort(sort),
                 states: stringifyStates(states),
-                query,
+                ...(query.length && { query }),
               },
             }),
         url: urlJoin(API.APPLICATIONS, appId),


### PR DESCRIPTION
Trim query value when sent to getApplications request, not in input value, so spaces can be used.
Send query param only when there's a value.