### PR TITLE
🐛 463 - Fix closed banner

### DIFF
--- a/components/pages/Applications/Dashboard/Applications/InProgress/index.tsx
+++ b/components/pages/Applications/Dashboard/Applications/InProgress/index.tsx
@@ -30,7 +30,6 @@ import { ApplicationsResponseItem } from 'components/pages/Applications/types';
 import { pick } from 'lodash';
 import { useTheme } from '@icgc-argo/uikit/ThemeProvider';
 import Link from '@icgc-argo/uikit/Link';
-import { Row } from 'react-grid-system';
 import { getConfig } from 'global/config';
 
 export interface StatusDates {
@@ -117,35 +116,47 @@ const InProgress = ({ application }: { application: ApplicationsResponseItem }) 
           </div>
         </Typography>
 
-        <Row
-          style={{
-            justifyContent: 'space-between',
-            alignItems: 'flex-end',
-            margin: 0,
-            height: '50px',
-          }}
+        <div
+          css={css`
+            display: flex;
+            justify-content: space-between;
+            align-items: flex-end;
+            margin: 0;
+            height: 50px;
+            flex-wrap: nowrap;
+          `}
         >
-          <ButtonGroup appId={appId} state={state as ApplicationState} />
-          {approvedAtUtc && state === ApplicationState.CLOSED && (
-            <div
-              css={(theme) => css`
-                padding: 6px 10px 6px 14px;
-                background-color: ${theme.colors.secondary_4};
-                border: 1px solid ${theme.colors.secondary_2};
-                border-radius: 8px;
-                width: 300px;
-                align-self: center;
-              `}
-            >
-              <Typography variant="data" bold>
-                <Link href={NEXT_PUBLIC_DACO_SURVEY_URL} target="_blank">
-                  Please fill out the required final report
-                </Link>{' '}
-                describing your experience with ICGC Controlled Data.
-              </Typography>
-            </div>
-          )}
-        </Row>
+          <div
+            css={css`
+              min-width: 160px;
+            `}
+          >
+            <ButtonGroup appId={appId} state={state as ApplicationState} />
+          </div>
+          <div
+            css={css`
+              max-width: 330px;
+            `}
+          >
+            {approvedAtUtc && state === ApplicationState.CLOSED && (
+              <div
+                css={(theme) => css`
+                  padding: 6px 10px 6px 14px;
+                  background-color: ${theme.colors.secondary_4};
+                  border: 1px solid ${theme.colors.secondary_2};
+                  border-radius: 8px;
+                `}
+              >
+                <Typography variant="data" bold>
+                  <Link href={NEXT_PUBLIC_DACO_SURVEY_URL} target="_blank">
+                    Please fill out the required final report
+                  </Link>{' '}
+                  describing your experience with ICGC Controlled Data.
+                </Typography>
+              </div>
+            )}
+          </div>
+        </div>
       </div>
     </DashboardCard>
   );

--- a/components/pages/Applications/ManageApplications/utils.tsx
+++ b/components/pages/Applications/ManageApplications/utils.tsx
@@ -34,6 +34,7 @@ import {
 import { ApplicationState } from 'components/ApplicationProgressBar/types';
 import { css } from '@icgc-argo/uikit';
 import { useTheme } from '@icgc-argo/uikit/ThemeProvider';
+import router from 'next/router';
 
 export const stringifySort = (sortArr: ApplicationsSort[]) =>
   sortArr.map(({ field, order }) => `${field}:${order}`).join(', ');
@@ -74,7 +75,9 @@ export const tableColumns: TableColumnConfig<ApplicationRecord> & {
     accessor: 'appId',
     Cell: ({ original }: { original: ApplicationRecord }) =>
       original.appId ? (
-        <Link href={urlJoin(APPLICATIONS_PATH, original.appId)}>{original.appId}</Link>
+        <Link onClick={() => router.push(urlJoin(APPLICATIONS_PATH, original.appId))}>
+          {original.appId}
+        </Link>
       ) : null,
   },
   {


### PR DESCRIPTION
Responsive alignment change for dashboard closed app badge.
Change admin table appId link to `router.push()` event to prevent shallow routing, allows use of path diffing for flash data reset