### PR TITLE
uikit version bump

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "dac-ui",
-  "version": "0.29.0",
+  "version": "0.31.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "0.29.0",
+      "version": "0.31.1",
       "dependencies": {
         "@emotion/babel-plugin": "^11.3.0",
         "@emotion/core": "^10.0.10",
         "@emotion/styled": "^10.0.11",
         "@icgc-argo/ego-token-utils": "^8.2.0",
-        "@icgc-argo/uikit": "1.14.0",
+        "@icgc-argo/uikit": "1.14.2",
         "@react-pdf/renderer": "^2.0.15",
         "axios": "^0.21.1",
         "babel-plugin-emotion": "^10.2.2",
@@ -2155,9 +2155,9 @@
       }
     },
     "node_modules/@icgc-argo/uikit": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@icgc-argo/uikit/-/uikit-1.14.0.tgz",
-      "integrity": "sha512-PSPlHi+pJNaRCbjJ85sZ7rSb5ERxvOa973N0i03Zq9r8dnwqH/IPjAT3bwz3yICLvzXsyBdkR7M5gwFsfpLgog==",
+      "version": "1.14.2",
+      "resolved": "https://registry.npmjs.org/@icgc-argo/uikit/-/uikit-1.14.2.tgz",
+      "integrity": "sha512-/iKfUaaQELObqwSzJHl1JhPqbO9rigzO6wVpR7pzp3Akl0kUd6nMAAhui4XrE7mYbiIoO8g0sLoWP999blL51Q==",
       "dependencies": {
         "@babel/runtime-corejs2": "^7.7.2",
         "@emotion/core": "^10.0.10",
@@ -23644,9 +23644,9 @@
       }
     },
     "@icgc-argo/uikit": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@icgc-argo/uikit/-/uikit-1.14.0.tgz",
-      "integrity": "sha512-PSPlHi+pJNaRCbjJ85sZ7rSb5ERxvOa973N0i03Zq9r8dnwqH/IPjAT3bwz3yICLvzXsyBdkR7M5gwFsfpLgog==",
+      "version": "1.14.2",
+      "resolved": "https://registry.npmjs.org/@icgc-argo/uikit/-/uikit-1.14.2.tgz",
+      "integrity": "sha512-/iKfUaaQELObqwSzJHl1JhPqbO9rigzO6wVpR7pzp3Akl0kUd6nMAAhui4XrE7mYbiIoO8g0sLoWP999blL51Q==",
       "requires": {
         "@babel/runtime-corejs2": "^7.7.2",
         "@emotion/core": "^10.0.10",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@emotion/core": "^10.0.10",
     "@emotion/styled": "^10.0.11",
     "@icgc-argo/ego-token-utils": "^8.2.0",
-    "@icgc-argo/uikit": "1.14.0",
+    "@icgc-argo/uikit": "1.14.2",
     "@react-pdf/renderer": "^2.0.15",
     "axios": "^0.21.1",
     "babel-plugin-emotion": "^10.2.2",


### PR DESCRIPTION
bumps uikit to 1.14.2, which gets rid of the name/change event on multiselect, and restores the higher-contrast disabled fields