### PR TITLE
✨ 472 - Add app history download button

### DIFF
--- a/components/pages/Applications/ApplicationForm/Header/Actions.tsx
+++ b/components/pages/Applications/ApplicationForm/Header/Actions.tsx
@@ -35,6 +35,7 @@ import Modal from '@icgc-argo/uikit/Modal';
 import router from 'next/router';
 import { RefetchDataFunction } from '../Forms/types';
 import Banner from '@icgc-argo/uikit/notifications/Banner';
+import { createDownloadInWindow } from 'global/utils/helpers';
 
 enum VisibleModalOption {
   NONE = 'NONE',
@@ -255,14 +256,9 @@ const HeaderActions = ({
               })
                 .then((res: any) => {
                   if (res.data && isDownloadZip) {
-                    const downloadUrl = window.URL.createObjectURL(new Blob([res.data]));
+                    const blob = new Blob([res.data]);
                     const filename = res.headers['content-disposition'].split('"')[1];
-                    const link = document.createElement('a');
-                    link.href = downloadUrl;
-                    link.setAttribute('download', filename);
-                    document.body.appendChild(link);
-                    link.click();
-                    link.remove();
+                    createDownloadInWindow(filename, blob);
                     setPdfIsLoading(false);
                     return {};
                   } else {

--- a/global/utils/helpers.ts
+++ b/global/utils/helpers.ts
@@ -1,0 +1,17 @@
+export const createDownloadInWindow = (filename: string, blobData: Blob) => {
+  const downloadUrl = window.URL.createObjectURL(blobData);
+  const link = document.createElement('a');
+  link.style.display = 'none';
+  link.href = downloadUrl;
+  link.setAttribute('download', filename);
+  // Comment from ARGO Platform UI: Safari thinks _blank anchor are pop ups. We only want to set _blank
+  // target if the browser does not support the HTML5 download attribute.
+  // This allows you to download files in desktop safari if pop up blocking
+  // is enabled.
+  if (typeof link.download === 'undefined') {
+    link.setAttribute('target', '_blank');
+  }
+  document.body.appendChild(link);
+  link.click();
+  link.remove();
+};


### PR DESCRIPTION
Adds app history download on admin table.
Creates helper function for window downloads.
Depends on [dac-api 227](https://github.com/icgc-argo/dac-api/pull/271)