### PR TITLE
🐛 439 - update pubs to use api side errors

### DIFF
--- a/components/pages/Applications/ApplicationForm/Forms/ProjectInfo/index.tsx
+++ b/components/pages/Applications/ApplicationForm/Forms/ProjectInfo/index.tsx
@@ -47,11 +47,13 @@ const ProjectInfo = ({
   localState,
   validateFieldTouched,
   sectionLastUpdatedAt,
+  errorsList,
 }: {
   isSectionDisabled: boolean;
   localState: FormSectionValidationState_ProjectInfo;
   validateFieldTouched: FormFieldValidationTriggerFunction;
   sectionLastUpdatedAt: string;
+  errorsList?: string[];
 }): ReactElement => {
   const { SectionTitle } = getStaticComponents(false);
   return (
@@ -212,6 +214,7 @@ const ProjectInfo = ({
         {...localState.publicationsURLs}
         isSectionDisabled={isSectionDisabled}
         validateFieldTouched={validateFieldTouched}
+        errorsList={errorsList}
       />
     </article>
   );

--- a/components/pages/Applications/ApplicationForm/Forms/helpers.tsx
+++ b/components/pages/Applications/ApplicationForm/Forms/helpers.tsx
@@ -98,6 +98,7 @@ export const sectionSelector = ({
       refetchAllData={formState.__refetchAllData}
       validateFieldTouched={validateFieldTouched}
       sectionLastUpdatedAt={sectionData[selectedSection].meta.lastUpdatedAtUtc}
+      errorsList={sectionData[selectedSection].meta.errorsList}
     />
   ) : (
     `Section not implemented: "${selectedSection}"`


### PR DESCRIPTION
Moves most publication error validation to backend; ui will display errors from api response
Empty field error remains with yup.
Notes on blank field error behaviour: 
- when a field is untouched, initial focus/blur event will create a blank field error, but on blur the form is submitted and the data is refreshed, and the item.error value is wiped from state.
- on a subsequent focus event, i.e. clicking the same empty field and blurring again, there is no data change so the form is NOT submitted and the item.error persists.
- once another field is modified, i.e. focussed, edited then blurred, the form is submitted and state is wiped again, erasing the empty field error on that previous field
- Due to the way the publications form is submitted, using api-side errors for blank fields results in overly aggressive error displays (errors will display on untouched fields because all existing pub fields in the form are submitted on every blur event)