### PR TITLE
🐛 583 - Persist required field error on all text fields

### DIFF
--- a/components/pages/Applications/ApplicationForm/Forms/types.ts
+++ b/components/pages/Applications/ApplicationForm/Forms/types.ts
@@ -307,7 +307,8 @@ export type FormFieldValidationTriggerFunction = (event: any) => Promise<void>;
 export type FormValidationFunctionArguments = {
   field?: string;
   value?: any;
-  shouldPersistResults?: Boolean;
+  shouldPersistResults?: boolean;
+  valueStayedEmpty?: boolean;
 };
 
 export type FormFieldValidatorFunction = (

--- a/components/pages/Applications/ApplicationForm/Forms/validations/helpers.ts
+++ b/components/pages/Applications/ApplicationForm/Forms/validations/helpers.ts
@@ -414,7 +414,9 @@ export const getFieldValues = (fieldsObj: any, isList: boolean): { [key: string]
     );
 };
 
-export const getUpdatedFields = (oldFields: any, newFields: any): string[] =>
+export const getUpdatedFields = (oldFields: any, newFields: any, currentField: string): string[] =>
   Object.keys(oldFields).filter(
-    (fieldName: string) => !isEqual(oldFields[fieldName].value, newFields[fieldName].value),
+    (fieldName: string) =>
+      !isEqual(oldFields[fieldName].value, newFields[fieldName].value) ||
+      (currentField === fieldName && !(oldFields[fieldName].value || newFields[fieldName].value)),
   );

--- a/components/pages/Applications/ApplicationForm/Forms/validations/helpers.ts
+++ b/components/pages/Applications/ApplicationForm/Forms/validations/helpers.ts
@@ -418,5 +418,7 @@ export const getUpdatedFields = (oldFields: any, newFields: any, currentField: s
   Object.keys(oldFields).filter(
     (fieldName: string) =>
       !isEqual(oldFields[fieldName].value, newFields[fieldName].value) ||
-      (currentField === fieldName && !(oldFields[fieldName].value || newFields[fieldName].value)),
+      (currentField === fieldName &&
+        oldFields[fieldName].value === '' &&
+        newFields[fieldName].value === ''),
   );

--- a/components/pages/Applications/ApplicationForm/Forms/validations/helpers.ts
+++ b/components/pages/Applications/ApplicationForm/Forms/validations/helpers.ts
@@ -418,6 +418,7 @@ export const getUpdatedFields = (oldFields: any, newFields: any, currentField: s
   Object.keys(oldFields).filter(
     (fieldName: string) =>
       !isEqual(oldFields[fieldName].value, newFields[fieldName].value) ||
+      // check if current field remains empty so it is regarded as "updated" for the purposes of triggering local state update
       (currentField === fieldName &&
         oldFields[fieldName].value === '' &&
         newFields[fieldName].value === ''),

--- a/components/pages/Applications/ApplicationForm/Forms/validations/index.ts
+++ b/components/pages/Applications/ApplicationForm/Forms/validations/index.ts
@@ -717,7 +717,7 @@ export const useLocalValidation = (
       const isList = sectionName === 'collaborators';
 
       switch (eventType) {
-        // **NOTE** Firefox and Chrome handle autofill events differently, see note in wiki: https://wiki.oicr.on.ca/display/icgcargotech/Frontend#Frontend-Autofill(DAC-UI)
+        // **NOTE** Firefox and Chrome handle autofill events differently, see note in Frontend wiki
         case 'blur': {
           if (
             sectionsWithAutoComplete.includes(sectionName) &&

--- a/components/pages/Applications/ApplicationForm/Forms/validations/index.ts
+++ b/components/pages/Applications/ApplicationForm/Forms/validations/index.ts
@@ -717,14 +717,7 @@ export const useLocalValidation = (
       const isList = sectionName === 'collaborators';
 
       switch (eventType) {
-        /**  **NOTE** Firefox and Chrome handle autofill events differently:
-        Chrome will fire a CHANGE event for each field that is autofilled, this updates local state but does not trigger an api request
-        The api request containing all changed fields will be triggered once the user blurs the focused field
-        Firefox will *immediately* fire a CHANGE and a BLUR event for each field that is autofilled, which triggers an api request *for each* autofilled field
-        github thread here: https://github.com/whatwg/html/issues/3016
-        older SO answer but references the general issue: https://stackoverflow.com/questions/11708092/detecting-browser-autofill/11710295#11710295
-        TODO: add notes about this to the frontend dev wiki
-        */
+        // **NOTE** Firefox and Chrome handle autofill events differently, see note in wiki: https://wiki.oicr.on.ca/display/icgcargotech/Frontend#Frontend-Autofill(DAC-UI)
         case 'blur': {
           if (
             sectionsWithAutoComplete.includes(sectionName) &&


### PR DESCRIPTION
Fixes bug where the required field error was not persisting on autocomplete fields when focusing/blurring with an empty value
- Adds a property `valueStayedEmpty` to prevent PATCH requests from firing when a field value remains an empty string after the blur event. `shouldPersistResults` was used for this check previously but caused unnecessary api requests on autocomplete fields
- Adds a comment about the different autofill behaviour of FF and Chrome