### PR TITLE
🐳  Fix npm ci command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ WORKDIR /usr/src
 
 COPY . /usr/src
 
-RUN npm ci
+RUN npm ci --legacy-peer-deps
 RUN npm run build
 
 EXPOSE 3000

--- a/Jenkinsfile.groovy
+++ b/Jenkinsfile.groovy
@@ -78,7 +78,7 @@ spec:
         stage('install & build') {
           steps {
             container('node') {
-              sh "npm ci"
+              sh "npm ci --legacy-peer-deps"
               sh "npm run build"
             }
           }


### PR DESCRIPTION
latest node 16 version uses npm 8.11.0, which needs the `--legacy-peer-deps` to work with uikit