### PR TITLE
Feat/#473 add annual attestation column to admin management table

### DIFF
--- a/components/pages/Applications/ManageApplications/utils.tsx
+++ b/components/pages/Applications/ManageApplications/utils.tsx
@@ -67,21 +67,9 @@ export const formatTableData = (data: ApplicationsResponseItem[]) =>
     accessExpiry: datum.closedAtUtc || datum.expiresAtUtc,
     lastUpdated: datum.lastUpdatedAtUtc,
     status: datum.state,
-    attestationBy: datum.attestationByUtc,
-    attestedAt: datum.attestedAtUtc,
+    attestationByUtc: datum.attestationByUtc,
+    attestedAtUtc: datum.attestedAtUtc,
     isAttestable: datum.isAttestable,
-
-    //  case 1: is attestable (entering 45 days prior to the due date and beyond) and attested (expect to have yes columns)
-    // attestedAt: datum.attestedAtUtc = "2022-06-20T13:40:53.311Z",
-    // isAttestable: true,
-
-    //case 2: is attestable and not attested (expect to have no columns)
-    // attestedAt: datum.attestedAtUtc,
-    // isAttestable: true,
-
-    // case 3: is not attestable and not attested (expect to have blank columns)
-    // attestedAt: datum.attestedAtUtc,
-    // isAttestable: false,
   }));
 
 export const tableColumns: TableColumnConfig<ApplicationRecord> & {
@@ -133,7 +121,7 @@ export const tableColumns: TableColumnConfig<ApplicationRecord> & {
     Header: fieldDisplayNames.attestedAtUtc,
     id: ApplicationsField.attestedAtUtc,
     Cell: ({ original }: { original: ApplicationRecord }) =>
-      original.attestedAt ? 'Yes' : original.isAttestable ? 'No' : ' ',
+      original.attestedAtUtc ? 'Yes' : original.isAttestable ? 'No' : ' ',
   },
   {
     Header: fieldDisplayNames.expiresAtUtc,

--- a/components/pages/Applications/types.ts
+++ b/components/pages/Applications/types.ts
@@ -32,8 +32,8 @@ export type ApplicationRecord = {
   status: string;
   country: string;
   currentApprovedAppDoc: boolean;
-  attestedAt: string;
-  attestationBy: string;
+  attestedAtUtc: string;
+  attestationByUtc: string;
   isAttestable: boolean;
 };
 


### PR DESCRIPTION
Add "Annual Attestation" column to admin manage application table.
Rows under this column have three outcome, `blank`, `yes`, or `no`.
`Yes` happens when `attestedAtUtc` is true. (application has completed the annual attestation)
`Blank` happens when `!attestedAtUtc && !isAttestable` (application is before 45 day prior to`attestationByUtc`, the due date and cannot perform annual attestation yet).
`No` happens when `!attestedAtUtc && isAttestable` (application is beyond 45 days prior to the due date, but is not attested).


 