### PR TITLE
feat/#484-display-attestation-banner-for-applicant-only

### DIFF
--- a/components/pages/Applications/ApplicationForm/Forms/index.tsx
+++ b/components/pages/Applications/ApplicationForm/Forms/index.tsx
@@ -87,6 +87,7 @@ const ApplicationFormsBase = ({
   isAttestable,
   attestedAtUtc,
   attestationByUtc = '',
+  isAdmin,
 }: {
   appId: string;
   applicationState: ApplicationState;
@@ -98,6 +99,7 @@ const ApplicationFormsBase = ({
   isAttestable: boolean;
   attestedAtUtc: string;
   attestationByUtc: string;
+  isAdmin: boolean;
 }): ReactElement => {
   const [visibleModal, setVisibleModal] = useState<VisibleModalOption>(VisibleModalOption.NONE);
 
@@ -186,7 +188,7 @@ const ApplicationFormsBase = ({
   return (
     <>
       <ContentBody>
-        {requiresAttestation && (
+        {requiresAttestation && !isAdmin && (
           <Notification
             title={
               <div

--- a/components/pages/Applications/ApplicationForm/index.tsx
+++ b/components/pages/Applications/ApplicationForm/index.tsx
@@ -75,6 +75,7 @@ const ApplicationForm = ({ appId = 'none', isAdmin = false }): ReactElement => {
         isAttestable={data?.isAttestable}
         attestedAtUtc={data?.attestedAtUtc}
         attestationByUtc={data?.attestationByUtc}
+        isAdmin={isAdmin}
       />
     </>
   ) : (


### PR DESCRIPTION
- continuing from the merged #484 branch
- using isAdmin prop to prevent admin side from seeing the attestation banner