### PR TITLE
♻️✏️ 484 - Refactoring for app access info, typo fix

### DIFF
--- a/components/pages/Applications/ApplicationForm/Header/Actions.tsx
+++ b/components/pages/Applications/ApplicationForm/Header/Actions.tsx
@@ -24,7 +24,6 @@ import Icon from '@icgc-argo/uikit/Icon';
 import { UikitTheme } from '@icgc-argo/uikit/index';
 import { useTheme } from '@icgc-argo/uikit/ThemeProvider';
 import urlJoin from 'url-join';
-import { isEqual } from 'lodash';
 import { useAuthContext } from 'global/hooks';
 import { API, APPLICATIONS_PATH, APPROVED_APP_CLOSED_CHECK } from 'global/constants';
 import { AxiosError } from 'axios';
@@ -42,7 +41,6 @@ enum VisibleModalOption {
   CLOSE_APPLICATION = 'CLOSE APPLICATION',
 }
 
-// EXPIRED and RENEWING handling is tbd, CLOSED excludes Action buttons
 const getPdfButtonText: (
   state: ApplicationState,
   approvedAtUtc: string,
@@ -54,7 +52,7 @@ const getPdfButtonText: (
     return `APPROVED ${text}`;
   }
 
-  if (ApplicationState.CLOSED.includes(state) && !!approvedAtUtc) {
+  if (state === ApplicationState.PAUSED || (state === ApplicationState.CLOSED && !!approvedAtUtc)) {
     return `SIGNED ${text}`;
   }
 
@@ -68,7 +66,7 @@ const getPdfButtonText: (
     return `DRAFT ${text}`;
   }
 
-  if (isEqual(state, ApplicationState.SIGN_AND_SUBMIT)) {
+  if (state === ApplicationState.SIGN_AND_SUBMIT) {
     return `FINALIZED ${text}`;
   }
 

--- a/components/pages/Applications/ApplicationForm/Header/Details.tsx
+++ b/components/pages/Applications/ApplicationForm/Header/Details.tsx
@@ -21,19 +21,22 @@ import { ReactElement } from 'react';
 import { css } from '@icgc-argo/uikit';
 import Link from '@icgc-argo/uikit/Link';
 import Typography from '@icgc-argo/uikit/Typography';
-import { APPLICATIONS_PATH } from 'global/constants';
+import { APPLICATIONS_PATH, DATE_TEXT_FORMAT } from 'global/constants';
 import { useTheme } from '@icgc-argo/uikit/ThemeProvider';
-import { ApplicationExpiry } from '.';
+import { ApplicationAccessInfo } from '.';
+import { format, parseISO } from 'date-fns';
 
-const Expiry = ({
-  date,
-  isExpired,
-  status,
-}: {
-  date: string;
-  isExpired: boolean;
-  status: string;
-}) => {
+const isValidDate = (val?: any): boolean => {
+  try {
+    parseISO(val);
+    return true;
+  } catch (e) {
+    console.warn(e);
+    return false;
+  }
+};
+
+const ApplicationAccessInfoDisplay = ({ date, isWarning, status }: ApplicationAccessInfo) => {
   const theme = useTheme();
   return (
     <>
@@ -41,10 +44,10 @@ const Expiry = ({
       |{' '}
       <span
         css={css`
-          color: ${theme.colors[isExpired ? 'error' : 'secondary']}; ;
+          color: ${theme.colors[isWarning ? 'error' : 'secondary']};
         `}
       >
-        {`${status}: ${date}`}
+        {`${status}: ${date && isValidDate(date) ? format(new Date(date), DATE_TEXT_FORMAT) : ''}`}
       </span>
     </>
   );
@@ -55,13 +58,13 @@ const HeaderDetails = ({
   createdAt,
   appId,
   lastUpdated,
-  expiry,
+  accessInfo,
 }: {
   applicant?: string;
   createdAt?: string;
   appId: string;
   lastUpdated?: string;
-  expiry?: ApplicationExpiry;
+  accessInfo?: ApplicationAccessInfo;
 }): ReactElement => {
   return (
     <section
@@ -77,8 +80,12 @@ const HeaderDetails = ({
         `}
       >
         <Link href={APPLICATIONS_PATH}>My Applications</Link>: {appId.toUpperCase()}
-        {expiry && (
-          <Expiry date={expiry.date} isExpired={expiry.isExpired} status={expiry.status} />
+        {accessInfo && (
+          <ApplicationAccessInfoDisplay
+            date={accessInfo.date}
+            isWarning={accessInfo.isWarning}
+            status={accessInfo.status}
+          />
         )}
       </Typography>
 

--- a/components/pages/Applications/types.ts
+++ b/components/pages/Applications/types.ts
@@ -238,6 +238,58 @@ interface Signature {
   signedAppDocObjId: string;
   uploadedAtUtc: string;
 }
+
+export enum AppType {
+  NEW = 'NEW',
+  RENEWAL = 'RENEWAL',
+}
+
+interface ApplicationInfo {
+  appType: AppType;
+  institution: string;
+  country: string;
+  applicant: string;
+  projectTitle: string;
+  ethicsLetterRequired: boolean | null;
+}
+
+export enum DacoRole {
+  SUBMITTER = 'SUBMITTER',
+  ADMIN = 'ADMIN',
+  SYSTEM = 'SYSTEM',
+}
+
+export type UpdateAuthor = {
+  id: string;
+  role: DacoRole;
+};
+// to differentiate update events from app State
+export enum UpdateEvent {
+  CREATED = 'CREATED',
+  SUBMITTED = 'SUBMITTED',
+  PAUSED = 'PAUSED',
+  REVISIONS_REQUESTED = 'REVISIONS REQUESTED',
+  ATTESTED = 'ATTESTED',
+  APPROVED = 'APPROVED',
+  EXPIRED = 'EXPIRED',
+  REJECTED = 'REJECTED',
+  CLOSED = 'CLOSED',
+}
+export interface ApplicationUpdate {
+  author: UpdateAuthor;
+  eventType: UpdateEvent;
+  date: string;
+  daysElapsed: number;
+  applicationInfo: ApplicationInfo;
+}
+
+export interface UserViewApplicationUpdate {
+  author: Partial<UpdateAuthor>;
+  eventType: UpdateEvent;
+  date: string;
+  applicationInfo: Partial<ApplicationInfo>;
+}
+
 export interface ApplicationData {
   appId: string;
   approvedAppDocs: ApprovedDoc[];
@@ -251,6 +303,7 @@ export interface ApplicationData {
   isAttestable: boolean;
   attestedAtUtc: string;
   attestationByUtc: string;
+  updates: ApplicationUpdate[] | UserViewApplicationUpdate[];
   sections: {
     applicant: Individual;
     representative: Representative;


### PR DESCRIPTION
Minor fixes/refactoring for `PAUSED` app ui
- fixes typo
- adds `PAUSED` app case for PDF button text
- refactors access info comp to account for other conditions besides expiry
- moaarr types
- uses `isAttestable` value from api instead of doing any assessment from ui side