### PR TITLE
👽️ 630 - correct pause date

### DIFF
--- a/components/pages/Applications/ApplicationForm/Forms/index.tsx
+++ b/components/pages/Applications/ApplicationForm/Forms/index.tsx
@@ -103,8 +103,8 @@ const ApplicationFormsBase = ({
   validateSection: FormSectionValidatorFunction_Origin;
   sectionData: ApplicationData['sections'];
   isAttestable: boolean;
-  attestedAtUtc: string;
-  attestationByUtc: string;
+  attestedAtUtc?: string;
+  attestationByUtc?: string;
   isAdmin: boolean;
   refetchAllData: any;
 }): ReactElement => {

--- a/components/pages/Applications/ApplicationForm/Header/index.tsx
+++ b/components/pages/Applications/ApplicationForm/Header/index.tsx
@@ -28,8 +28,7 @@ import Details from './Details';
 import Progress from './Progress';
 import { RefetchDataFunction } from '../Forms/types';
 import { ApplicationState } from 'components/ApplicationProgressBar/types';
-import { ApplicationData, UpdateEvent } from '../../types';
-import { findLast, sortBy } from 'lodash';
+import { ApplicationData } from '../../types';
 
 export type ApplicationAccessInfo = { date?: string; isWarning: boolean; status: string };
 
@@ -53,7 +52,7 @@ const ApplicationHeader = ({
     approvedAppDocs,
     isAttestable,
     attestationByUtc,
-    updates,
+    lastPausedAtUtc,
   } = data;
 
   const applicant = `${displayName}${primaryAffiliation ? `. ${primaryAffiliation}` : ''}`;
@@ -69,13 +68,8 @@ const ApplicationHeader = ({
     state === ApplicationState.PAUSED
       ? {
           date:
-            // updates should appear in asc order by date but just ensuring it
-            // retrieving the most recent PAUSED event; in future applications could be paused several times
             // otherwise display calculated attestationBy date, the assumption is the app is paused due to missing attestation
-            findLast(
-              sortBy(updates, (u) => u.date),
-              (update) => update.eventType === UpdateEvent.PAUSED,
-            )?.date || attestationByUtc,
+            lastPausedAtUtc || attestationByUtc,
           isWarning: true,
           status: '! Paused',
         }

--- a/components/pages/Applications/ApplicationForm/Header/index.tsx
+++ b/components/pages/Applications/ApplicationForm/Header/index.tsx
@@ -63,7 +63,7 @@ const ApplicationHeader = ({
     revisionsRequested &&
     [ApplicationState.REVISIONS_REQUESTED, ApplicationState.SIGN_AND_SUBMIT].includes(state);
 
-  // only pass expiry for applications that have been approved
+  // only pass accessInfo for applications that have been approved
   // add 'status' key to allow easy string changes
   const accessInfo =
     state === ApplicationState.PAUSED

--- a/components/pages/Applications/Dashboard/Applications/InProgress/helpers.ts
+++ b/components/pages/Applications/Dashboard/Applications/InProgress/helpers.ts
@@ -17,17 +17,28 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import { ApplicationState } from 'components/ApplicationProgressBar/types';
+import { pick } from 'lodash';
 import { format as formatDate } from 'date-fns';
+
+import { ApplicationState } from 'components/ApplicationProgressBar/types';
+import { ApplicationSummary } from 'components/pages/Applications/types';
 import { DATE_TEXT_FORMAT } from 'global/constants';
 import { StatusDates } from '.';
 
-export const getStatusText = (
-  state: ApplicationState,
-  dates: StatusDates,
-  revisionsRequested: boolean,
-  requiresAttestation: boolean,
-) => {
+export const getStatusText = (application: ApplicationSummary) => {
+  const { lastUpdatedAtUtc, isAttestable, state, revisionsRequested } = application;
+  const dates: StatusDates = {
+    lastUpdatedAtUtc,
+    ...pick(application, [
+      'createdAtUtc',
+      'submittedAtUtc',
+      'closedAtUtc',
+      'approvedAtUtc',
+      'attestedAtUtc',
+      'attestationByUtc',
+      'lastPausedAtUtc',
+    ]),
+  };
   const formatStatusDate = (date: string) =>
     formatDate(new Date(date || dates.lastUpdatedAtUtc), DATE_TEXT_FORMAT);
 
@@ -38,7 +49,7 @@ export const getStatusText = (
 
   switch (state) {
     case ApplicationState.APPROVED:
-      return requiresAttestation
+      return isAttestable
         ? `An annual attestation is required for this application. Access for this project team will be paused on ${formatStatusDate(
             dates.attestationByUtc,
           )} until you submit your attestation.`
@@ -67,7 +78,7 @@ export const getStatusText = (
       return `Closed on ${formatStatusDate(dates.closedAtUtc)}.`;
     case ApplicationState.PAUSED:
       return `Access was paused on ${formatStatusDate(
-        dates.attestationByUtc,
+        dates.lastPausedAtUtc || dates.attestationByUtc,
       )}. Access for this project team will resume once you submit the annual attestation for this application.`;
     default:
       return '';

--- a/components/pages/Applications/Dashboard/Applications/index.tsx
+++ b/components/pages/Applications/Dashboard/Applications/index.tsx
@@ -20,7 +20,7 @@
 import InProgress from './InProgress';
 import StartApplication from './Start';
 import { css } from '@emotion/core';
-import { ApplicationsField, ApplicationsResponseItem } from 'components/pages/Applications/types';
+import { ApplicationsField, ApplicationSummary } from 'components/pages/Applications/types';
 import { isEmpty } from 'lodash';
 import { useGetApplications } from 'global/hooks';
 import Loader from 'components/Loader';
@@ -62,7 +62,7 @@ const Applications = () => {
       `}
     >
       {!isEmpty(applications) &&
-        applications.map((application: ApplicationsResponseItem) => (
+        applications.map((application: ApplicationSummary) => (
           <InProgress application={application} key={application.appId} />
         ))}
       {!collabAppsLoading && !collabError && collabResponse?.data.length > 0 && (

--- a/components/pages/Applications/ManageApplications/utils.tsx
+++ b/components/pages/Applications/ManageApplications/utils.tsx
@@ -27,7 +27,7 @@ import { APPLICATIONS_PATH } from 'global/constants/internalPaths';
 import {
   ApplicationRecord,
   ApplicationsField,
-  ApplicationsResponseItem,
+  ApplicationSummary,
   ApplicationsSort,
 } from '../types';
 
@@ -55,8 +55,8 @@ export const fieldDisplayNames = {
   currentApprovedAppDoc: 'Approved PDF',
 };
 
-export const formatTableData = (data: ApplicationsResponseItem[]) =>
-  data.map<ApplicationRecord>((datum: ApplicationsResponseItem) => ({
+export const formatTableData = (data: ApplicationSummary[]) =>
+  data.map<ApplicationRecord>((datum: ApplicationSummary) => ({
     appId: datum.appId,
     institution: datum.applicant.info.primaryAffiliation,
     country: datum.applicant.address.country,

--- a/components/pages/Applications/types.ts
+++ b/components/pages/Applications/types.ts
@@ -302,8 +302,9 @@ export interface ApplicationData {
   approvedAtUtc: string;
   state: ApplicationState;
   isAttestable: boolean;
-  attestedAtUtc: string;
-  attestationByUtc: string;
+  attestedAtUtc?: string;
+  attestationByUtc?: string;
+  lastPausedAtUtc?: string;
   updates: ApplicationUpdate[] | UserViewApplicationUpdate[];
   sections: {
     applicant: Individual;

--- a/components/pages/Applications/types.ts
+++ b/components/pages/Applications/types.ts
@@ -84,7 +84,7 @@ export interface Agreement {
   accepted: boolean;
 }
 
-export type ApplicationsResponseItem = {
+export type ApplicationSummary = {
   appId: string;
   applicant: {
     info: {
@@ -101,7 +101,7 @@ export type ApplicationsResponseItem = {
   };
   expiresAtUtc: string;
   lastUpdatedAtUtc: string;
-  state: string;
+  state: ApplicationState;
   createdAtUtc: string;
   submittedAtUtc: string;
   closedAtUtc: string;
@@ -111,6 +111,7 @@ export type ApplicationsResponseItem = {
   attestedAtUtc: string;
   attestationByUtc: string;
   isAttestable: boolean;
+  lastPausedAtUtc?: string;
 };
 
 export type ApplicationDataByField = {
@@ -322,7 +323,7 @@ export type ApplicationsResponseData = {
     pagesCount: number;
     index: number;
   };
-  items: ApplicationsResponseItem[];
+  items: ApplicationSummary[];
 };
 
 export enum ApplicationsField {


### PR DESCRIPTION
Use `lastPausedAtUtc` value from api instead of calculating from updates array and `attestationByUtc`
- `attestationByUtc` will still be a fallback value, but if an application is in `PAUSED` state there should be at least one paused event in the updates list
- uses changes from https://github.com/icgc-argo/dac-api/pull/343
- Also some type renaming to align more with api types because it wasn't clear to me what `ApplicationsResponseItem` was 🙂  