### PR TITLE
✨ 504 - Add expiring status, renew button to dashboard card

### DIFF
--- a/components/pages/Applications/Dashboard/Applications/InProgress/ButtonGroup.tsx
+++ b/components/pages/Applications/Dashboard/Applications/InProgress/ButtonGroup.tsx
@@ -17,15 +17,20 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import { Fragment } from 'react';
+import { Fragment, ReactNode } from 'react';
 import { css } from '@emotion/core';
 import Button from '@icgc-argo/uikit/Button';
 import Icon from '@icgc-argo/uikit/Icon';
 import { ApplicationState } from 'components/ApplicationProgressBar/types';
 import router from 'next/router';
-import { APPLICATIONS_PATH } from 'global/constants';
+import { API, APPLICATIONS_PATH, RENEWAL_PATH } from 'global/constants';
 import urlJoin from 'url-join';
 import { UikitIconNames } from '@icgc-argo/uikit/Icon/icons';
+import { useAuthContext } from 'global/hooks';
+import { AxiosResponse } from 'axios';
+import { ApplicationData } from 'components/pages/Applications/types';
+import { TOAST_VARIANTS } from '@icgc-argo/uikit/notifications/Toast';
+import { useToaster } from 'global/hooks/useToaster';
 
 const ButtonIcon = ({ name }: { name: UikitIconNames }) => {
   return (
@@ -40,19 +45,74 @@ const ButtonIcon = ({ name }: { name: UikitIconNames }) => {
   );
 };
 
-const icons = {
-  file: <ButtonIcon name="file" />,
-  edit: <ButtonIcon name="edit" />,
-  user: <ButtonIcon name="user" />,
-  reset: <ButtonIcon name="reset" />,
-  calendar: <ButtonIcon name="calendar" />,
+const RenewButton = ({
+  children,
+  appId,
+  link,
+}: {
+  children: ReactNode;
+  appId: string;
+  link: string;
+}): JSX.Element => {
+  const { fetchWithAuth } = useAuthContext();
+  const toaster = useToaster();
+  return (
+    <Button
+      className="action-btns"
+      size="sm"
+      onClick={async () => {
+        await fetchWithAuth({
+          url: link,
+          method: 'POST',
+        })
+          .then(async (res: AxiosResponse) => {
+            if (res.status === 201) {
+              const appData: ApplicationData = res.data;
+              router.push(urlJoin(APPLICATIONS_PATH, appData.appId, '?section=terms'));
+            }
+          })
+          .catch((err: Error) => {
+            toaster.addToast({
+              variant: TOAST_VARIANTS.ERROR,
+              title: 'Renewal Failed',
+              content: `There was an error while trying to create a renewal application for ${appId}. Please try again later.`,
+              interactionType: 'CLOSE',
+            });
+          });
+      }}
+    >
+      <span
+        css={css`
+          margin-right: 3px;
+        `}
+      >
+        <Icon
+          name="reset"
+          fill="white"
+          height="12px"
+          css={css`
+            margin-bottom: -2px;
+            margin-right: 2px;
+            transform: scaleX(-1);
+          `}
+        />
+      </span>
+      {children}
+    </Button>
+  );
 };
 
 const getButtonConfig = (
-  appId = '',
-  state = '',
-  requiresAttestation = false,
-): { content: string; link: string; icon: any }[] => {
+  appId: string = '',
+  state: ApplicationState,
+  requiresAttestation: boolean = false,
+  ableToRenew: boolean,
+): {
+  content: string;
+  link: string;
+  icon?: UikitIconNames;
+  CustomButton?: (props: any) => JSX.Element;
+}[] => {
   const link = urlJoin(APPLICATIONS_PATH, appId);
   switch (state) {
     case ApplicationState.DRAFT:
@@ -62,18 +122,17 @@ const getButtonConfig = (
         {
           content: 'Edit Application',
           link,
-          icon: icons.edit,
+          icon: 'edit',
         },
       ];
     case ApplicationState.REVIEW:
     case ApplicationState.REJECTED:
-    // closed after approval
     case ApplicationState.CLOSED:
       return [
         {
           content: 'View Application',
           link,
-          icon: icons.file,
+          icon: 'file',
         },
       ];
     case ApplicationState.APPROVED:
@@ -82,41 +141,41 @@ const getButtonConfig = (
             {
               content: 'Complete Attestation',
               link,
-              icon: icons.calendar,
+              icon: 'calendar',
+            },
+          ]
+        : ableToRenew
+        ? [
+            {
+              content: 'Renew Application',
+              CustomButton: RenewButton,
+              link: urlJoin(API.APPLICATIONS, appId, RENEWAL_PATH),
+            },
+            {
+              content: 'View Application',
+              link,
+              icon: 'file',
             },
           ]
         : [
             {
               content: 'View Application',
               link,
-              icon: icons.file,
+              icon: 'file',
             },
             {
               content: 'Manage Collaborators',
               link: urlJoin(link, '?section=collaborators'),
-              icon: icons.user,
+              icon: 'user',
             },
           ];
-    //Paused state implies attestation is needed
+    // Paused state implies attestation is needed
     case ApplicationState.PAUSED:
       return [
         {
           content: 'Complete Attestation',
           link,
-          icon: icons.calendar,
-        },
-      ];
-    case ApplicationState.CLOSED:
-      return [
-        {
-          content: 'View Application',
-          link,
-          icon: icons.file,
-        },
-        {
-          content: 'Reopen',
-          link,
-          icon: icons.reset,
+          icon: 'calendar',
         },
       ];
   }
@@ -127,37 +186,47 @@ const ButtonGroup = ({
   appId,
   state,
   requiresAttestation,
+  ableToRenew,
 }: {
   appId: string;
   state: ApplicationState;
   requiresAttestation: boolean;
+  ableToRenew: boolean;
 }) => (
   <div
     css={css`
       display: flex;
     `}
   >
-    {getButtonConfig(appId, state, requiresAttestation).map(({ content, link, icon }, index) => (
-      <Fragment key={link}>
-        <Button
-          className="action-btns"
-          size="sm"
-          onClick={() => router.push(link)}
-          css={css`
-            margin-left: ${index ? '8px !important;' : 0};
-          `}
-        >
-          <span
-            css={css`
-              margin-right: 3px;
-            `}
-          >
-            {icon}
-          </span>
-          {content}
-        </Button>
-      </Fragment>
-    ))}
+    {getButtonConfig(appId, state, requiresAttestation, ableToRenew).map(
+      ({ content, link, icon, CustomButton }, index) => (
+        <Fragment key={link}>
+          {CustomButton ? (
+            <CustomButton appId={appId} link={link}>
+              {content}
+            </CustomButton>
+          ) : (
+            <Button
+              className="action-btns"
+              size="sm"
+              onClick={() => router.push(link)}
+              css={css`
+                margin-left: ${index ? '8px !important;' : 0};
+              `}
+            >
+              <span
+                css={css`
+                  margin-right: 3px;
+                `}
+              >
+                <ButtonIcon name={icon} />
+              </span>
+              {content}
+            </Button>
+          )}
+        </Fragment>
+      ),
+    )}
   </div>
 );
 

--- a/components/pages/Applications/Dashboard/Applications/InProgress/ButtonGroup.tsx
+++ b/components/pages/Applications/Dashboard/Applications/InProgress/ButtonGroup.tsx
@@ -49,10 +49,12 @@ const RenewButton = ({
   children,
   appId,
   link,
+  icon,
 }: {
   children: ReactNode;
   appId: string;
   link: string;
+  icon: UikitIconNames;
 }): JSX.Element => {
   const { fetchWithAuth } = useAuthContext();
   const toaster = useToaster();
@@ -87,7 +89,7 @@ const RenewButton = ({
         `}
       >
         <Icon
-          name="reset"
+          name={icon}
           fill="white"
           height="12px"
           css={css`
@@ -110,7 +112,7 @@ const getButtonConfig = (
 ): {
   content: string;
   link: string;
-  icon?: UikitIconNames;
+  icon: UikitIconNames;
   CustomButton?: (props: any) => JSX.Element;
 }[] => {
   const link = urlJoin(APPLICATIONS_PATH, appId);
@@ -149,6 +151,7 @@ const getButtonConfig = (
             {
               content: 'Renew Application',
               CustomButton: RenewButton,
+              icon: 'reset',
               link: urlJoin(API.APPLICATIONS, appId, RENEWAL_PATH),
             },
             {
@@ -202,7 +205,7 @@ const ButtonGroup = ({
       ({ content, link, icon, CustomButton }, index) => (
         <Fragment key={link}>
           {CustomButton ? (
-            <CustomButton appId={appId} link={link}>
+            <CustomButton appId={appId} link={link} icon={icon}>
               {content}
             </CustomButton>
           ) : (

--- a/components/pages/Applications/Dashboard/Applications/InProgress/helpers.ts
+++ b/components/pages/Applications/Dashboard/Applications/InProgress/helpers.ts
@@ -18,7 +18,7 @@
  */
 
 import { pick } from 'lodash';
-import { format as formatDate } from 'date-fns';
+import { format as formatDate, addDays } from 'date-fns';
 
 import { ApplicationState } from 'components/ApplicationProgressBar/types';
 import { ApplicationSummary } from 'components/pages/Applications/types';
@@ -63,7 +63,7 @@ export const getStatusText = (application: ApplicationSummary) => {
           )} until you submit your attestation.`
         : ableToRenew || (renewalAppId && state === ApplicationState.APPROVED)
         ? `Access is expiring soon. To extend your access privileges for another two years, please renew this application by ${formatStatusDate(
-            dates.expiresAtUtc,
+            getRenewalPeriodEndDate(dates.expiresAtUtc),
           )}.`
         : `Approved on ${formatStatusDate(
             dates.approvedAtUtc,
@@ -97,3 +97,11 @@ export const getStatusText = (application: ApplicationSummary) => {
 
 export const getFormattedDate = (date: string | number | Date, format: string) =>
   date ? formatDate(new Date(date), format) : '';
+
+// calculate the last day an app can be renewed, expiry + configured days post expiry
+// DACO allows 90 days after expiry to renew
+export const getRenewalPeriodEndDate = (expiryDate: string): string => {
+  const expiry = new Date(expiryDate);
+  // TODO: Get rid of hardcoded num days. Can the configured days after expiry be retrieved from the BE?
+  return addDays(expiry, 90).toDateString();
+};

--- a/components/pages/Applications/Dashboard/Applications/InProgress/helpers.ts
+++ b/components/pages/Applications/Dashboard/Applications/InProgress/helpers.ts
@@ -26,7 +26,14 @@ import { DATE_TEXT_FORMAT } from 'global/constants';
 import { StatusDates } from '.';
 
 export const getStatusText = (application: ApplicationSummary) => {
-  const { lastUpdatedAtUtc, isAttestable, state, revisionsRequested } = application;
+  const {
+    lastUpdatedAtUtc,
+    isAttestable,
+    state,
+    revisionsRequested,
+    ableToRenew,
+    renewalAppId,
+  } = application;
   const dates: StatusDates = {
     lastUpdatedAtUtc,
     ...pick(application, [
@@ -37,6 +44,7 @@ export const getStatusText = (application: ApplicationSummary) => {
       'attestedAtUtc',
       'attestationByUtc',
       'lastPausedAtUtc',
+      'expiresAtUtc',
     ]),
   };
   const formatStatusDate = (date: string) =>
@@ -53,6 +61,10 @@ export const getStatusText = (application: ApplicationSummary) => {
         ? `An annual attestation is required for this application. Access for this project team will be paused on ${formatStatusDate(
             dates.attestationByUtc,
           )} until you submit your attestation.`
+        : ableToRenew || (renewalAppId && state === ApplicationState.APPROVED)
+        ? `Access is expiring soon. To extend your access privileges for another two years, please renew this application by ${formatStatusDate(
+            dates.expiresAtUtc,
+          )}.`
         : `Approved on ${formatStatusDate(
             dates.approvedAtUtc,
           )}. You now have access to ICGC Controlled Data.`;

--- a/components/pages/Applications/Dashboard/Applications/InProgress/index.tsx
+++ b/components/pages/Applications/Dashboard/Applications/InProgress/index.tsx
@@ -136,8 +136,10 @@ const InProgress = ({ application }: { application: ApplicationSummary }) => {
   const statusDate = getStatusDate(application);
 
   const statusError =
-    isAttestable || ableToRenew || (renewalAppId && state === ApplicationState.APPROVED);
-  state === ApplicationState.PAUSED ||
+    isAttestable ||
+    ableToRenew ||
+    (renewalAppId && state === ApplicationState.APPROVED) ||
+    state === ApplicationState.PAUSED ||
     (revisionsRequested &&
       [ApplicationState.REVISIONS_REQUESTED, ApplicationState.SIGN_AND_SUBMIT].includes(state));
 

--- a/components/pages/Applications/Dashboard/Applications/InProgress/index.tsx
+++ b/components/pages/Applications/Dashboard/Applications/InProgress/index.tsx
@@ -43,8 +43,78 @@ export interface StatusDates {
   attestedAtUtc: string;
   attestationByUtc: string;
   lastPausedAtUtc?: string;
+  expiresAtUtc: string;
 }
 
+const getStatusDate = (application: ApplicationSummary): any => {
+  const {
+    state,
+    expiresAtUtc,
+    closedAtUtc,
+    approvedAtUtc,
+    attestationByUtc,
+    isAttestable,
+    ableToRenew,
+    lastPausedAtUtc,
+    renewalAppId,
+  } = application;
+  switch (true) {
+    case state === ApplicationState.PAUSED:
+      return (
+        <div
+          css={(theme) => css`
+            color: ${theme.colors.error};
+          `}
+        >
+          {`! Access Paused: ${getFormattedDate(
+            lastPausedAtUtc || attestationByUtc,
+            DATE_TEXT_FORMAT,
+          )}`}
+        </div>
+      );
+      break;
+    case isAttestable:
+      return (
+        <div
+          css={(theme) => css`
+            color: ${theme.colors.error};
+          `}
+        >{`! Access Pausing: ${getFormattedDate(attestationByUtc, DATE_TEXT_FORMAT)}`}</div>
+      );
+      break;
+    // TODO: add state === EXPIRED case before ableToRenew case (https://github.com/icgc-argo/dac-ui/issues/505)
+    // ableToRenew becomes false once a renewal is created, but we still want to display the "Expiring" text state
+    case ableToRenew || (renewalAppId && state === ApplicationState.APPROVED):
+      return (
+        <div
+          css={(theme) => css`
+            color: ${theme.colors.error};
+          `}
+        >{`! Access Expiring: ${getFormattedDate(expiresAtUtc, DATE_TEXT_FORMAT)}`}</div>
+      );
+      break;
+    case expiresAtUtc && !closedAtUtc:
+      return (
+        <div
+          css={(theme) => css`
+            color: ${theme.colors.secondary};
+          `}
+        >{`Access Expiry: ${getFormattedDate(expiresAtUtc, DATE_TEXT_FORMAT)}`}</div>
+      );
+      break;
+    case !!closedAtUtc && !!approvedAtUtc:
+      return (
+        <div
+          css={(theme) => css`
+            color: ${theme.colors.error};
+          `}
+        >{`Access Expired: ${getFormattedDate(closedAtUtc, DATE_TEXT_FORMAT)}`}</div>
+      );
+      break;
+    default:
+      return null;
+  }
+};
 const InProgress = ({ application }: { application: ApplicationSummary }) => {
   const theme = useTheme();
   const { NEXT_PUBLIC_DACO_SURVEY_URL } = getConfig();
@@ -55,50 +125,19 @@ const InProgress = ({ application }: { application: ApplicationSummary }) => {
       info: { primaryAffiliation },
     },
     state,
-    expiresAtUtc,
     lastUpdatedAtUtc,
-    closedAtUtc,
     approvedAtUtc,
     revisionsRequested,
-    attestationByUtc,
     isAttestable,
+    ableToRenew,
+    renewalAppId,
   } = application;
 
-  const statusDate =
-    state === ApplicationState.PAUSED ? (
-      <div
-        css={css`
-          color: ${theme.colors.error};
-        `}
-      >
-        {`! Access Paused: ${getFormattedDate(
-          application.lastPausedAtUtc || application.attestationByUtc,
-          DATE_TEXT_FORMAT,
-        )}`}
-      </div>
-    ) : isAttestable ? (
-      <div
-        css={css`
-          color: ${theme.colors.error};
-        `}
-      >{`! Access Pausing: ${getFormattedDate(attestationByUtc, DATE_TEXT_FORMAT)}`}</div>
-    ) : expiresAtUtc && !closedAtUtc ? (
-      <div
-        css={css`
-          color: ${theme.colors.secondary};
-        `}
-      >{`Access Expiry: ${getFormattedDate(expiresAtUtc, DATE_TEXT_FORMAT)}`}</div>
-    ) : closedAtUtc && approvedAtUtc ? (
-      <div
-        css={css`
-          color: ${theme.colors.error};
-        `}
-      >{`Access Expired: ${getFormattedDate(closedAtUtc, DATE_TEXT_FORMAT)}`}</div>
-    ) : null;
+  const statusDate = getStatusDate(application);
 
   const statusError =
-    isAttestable ||
-    state === ApplicationState.PAUSED ||
+    isAttestable || ableToRenew || (renewalAppId && state === ApplicationState.APPROVED);
+  state === ApplicationState.PAUSED ||
     (revisionsRequested &&
       [ApplicationState.REVISIONS_REQUESTED, ApplicationState.SIGN_AND_SUBMIT].includes(state));
 
@@ -154,7 +193,12 @@ const InProgress = ({ application }: { application: ApplicationSummary }) => {
               min-width: 160px;
             `}
           >
-            <ButtonGroup appId={appId} state={state} requiresAttestation={isAttestable} />
+            <ButtonGroup
+              appId={appId}
+              state={state}
+              requiresAttestation={isAttestable}
+              ableToRenew={ableToRenew}
+            />
           </div>
           <div
             css={css`

--- a/components/pages/Applications/types.ts
+++ b/components/pages/Applications/types.ts
@@ -115,6 +115,7 @@ export type ApplicationSummary = {
   lastPausedAtUtc?: string;
   isRenewal: boolean;
   ableToRenew: boolean;
+  renewalAppId?: string;
 };
 
 export type ApplicationDataByField = {

--- a/global/constants/internalPaths.ts
+++ b/global/constants/internalPaths.ts
@@ -22,3 +22,4 @@ export const LOGGED_IN_PATH = '/logged-in';
 export const PRIVATE_PATHS = [APPLICATIONS_PATH];
 export const ERROR_PATH = '/_error';
 export const NEW_WEBSITE_NOTICE_PATH = '/new-website-notice';
+export const RENEWAL_PATH = '/renew';


### PR DESCRIPTION
Dashboard status text, date and renew button for approved applications within the renewal period (before expiry).
Refactors some of the conditionals for status display.
Allows a custom Button component
Adds calc function for renewal period end date (expiry + 90 days) - currently this is hardcoded, either switch to a configurable value, or get this value from the BE in some form (a new field or retrieve config from api)