### PR TITLE
✨ 505 - add status text and date for expired dashboard apps

### DIFF
--- a/components/pages/Applications/Dashboard/Applications/InProgress/ButtonGroup.tsx
+++ b/components/pages/Applications/Dashboard/Applications/InProgress/ButtonGroup.tsx
@@ -172,6 +172,29 @@ const getButtonConfig = (
               icon: 'user',
             },
           ];
+    case ApplicationState.EXPIRED:
+      return ableToRenew
+        ? [
+            {
+              content: 'Renew Application',
+              CustomButton: RenewButton,
+              icon: 'reset',
+              link: urlJoin(API.APPLICATIONS, appId, RENEWAL_PATH),
+            },
+            {
+              content: 'View Application',
+              link,
+              icon: 'file',
+            },
+          ]
+        : [
+            {
+              content: 'View Application',
+              link,
+              icon: 'file',
+            },
+          ];
+      break;
     // Paused state implies attestation is needed
     case ApplicationState.PAUSED:
       return [
@@ -181,8 +204,9 @@ const getButtonConfig = (
           icon: 'calendar',
         },
       ];
+    default:
+      return [];
   }
-  return [];
 };
 
 const ButtonGroup = ({

--- a/components/pages/Applications/Dashboard/Applications/InProgress/helpers.ts
+++ b/components/pages/Applications/Dashboard/Applications/InProgress/helpers.ts
@@ -90,6 +90,13 @@ export const getStatusText = (application: ApplicationSummary) => {
       return `Access was paused on ${formatStatusDate(
         dates.lastPausedAtUtc || dates.attestationByUtc,
       )}. Access for this project team will resume once you submit the annual attestation for this application.`;
+    case ApplicationState.EXPIRED:
+      const renewalEndDate = formatStatusDate(getRenewalPeriodEndDate(dates.expiresAtUtc));
+      return ableToRenew
+        ? `Access has expired. To extend your access privileges for another two years, please renew this application by ${renewalEndDate}.`
+        : renewalAppId
+        ? `An application renewal has been created. Please complete application ${renewalAppId} to extend your access privileges for another two years. This must be completed by ${renewalEndDate}.`
+        : 'The renewal period for this application has ended. If you have not completed a renewal application, you will need to start a new application to gain access privileges for another two years.';
     default:
       return '';
   }

--- a/components/pages/Applications/Dashboard/Applications/InProgress/helpers.ts
+++ b/components/pages/Applications/Dashboard/Applications/InProgress/helpers.ts
@@ -18,12 +18,13 @@
  */
 
 import { pick } from 'lodash';
-import { format as formatDate, addDays } from 'date-fns';
+import { format as formatDate } from 'date-fns';
 
 import { ApplicationState } from 'components/ApplicationProgressBar/types';
 import { ApplicationSummary } from 'components/pages/Applications/types';
 import { DATE_TEXT_FORMAT } from 'global/constants';
 import { StatusDates } from '.';
+import { getRenewalPeriodEndDate } from 'global/utils/dates/helpers';
 
 export const getStatusText = (application: ApplicationSummary) => {
   const {
@@ -104,11 +105,3 @@ export const getStatusText = (application: ApplicationSummary) => {
 
 export const getFormattedDate = (date: string | number | Date, format: string) =>
   date ? formatDate(new Date(date), format) : '';
-
-// calculate the last day an app can be renewed, expiry + configured days post expiry
-// DACO allows 90 days after expiry to renew
-export const getRenewalPeriodEndDate = (expiryDate: string): string => {
-  const expiry = new Date(expiryDate);
-  // TODO: Get rid of hardcoded num days. Can the configured days after expiry be retrieved from the BE?
-  return addDays(expiry, 90).toDateString();
-};

--- a/components/pages/Applications/Dashboard/Applications/InProgress/index.tsx
+++ b/components/pages/Applications/Dashboard/Applications/InProgress/index.tsx
@@ -33,6 +33,7 @@ import { DATE_TEXT_FORMAT } from 'global/constants';
 import { ApplicationSummary } from 'components/pages/Applications/types';
 
 import { getConfig } from 'global/config';
+import { isRenewalPeriodEnded } from 'global/utils/dates/helpers';
 
 export interface StatusDates {
   lastUpdatedAtUtc: string;
@@ -142,15 +143,16 @@ const InProgress = ({ application }: { application: ApplicationSummary }) => {
     isAttestable,
     ableToRenew,
     renewalAppId,
+    expiresAtUtc,
   } = application;
 
   const statusDate = getStatusDate(application);
-
-  // TODO: an application that is past the renewal period and has no renewalAppId (no renewal has been created) will show in default text colour
   const statusError =
     isAttestable ||
     ableToRenew ||
-    (renewalAppId && [ApplicationState.APPROVED, ApplicationState.EXPIRED].includes(state)) ||
+    (renewalAppId &&
+      [ApplicationState.APPROVED, ApplicationState.EXPIRED].includes(state) &&
+      !isRenewalPeriodEnded(expiresAtUtc)) ||
     state === ApplicationState.PAUSED ||
     (revisionsRequested &&
       [ApplicationState.REVISIONS_REQUESTED, ApplicationState.SIGN_AND_SUBMIT].includes(state));

--- a/components/pages/Applications/Dashboard/Applications/InProgress/index.tsx
+++ b/components/pages/Applications/Dashboard/Applications/InProgress/index.tsx
@@ -82,7 +82,17 @@ const getStatusDate = (application: ApplicationSummary): any => {
         >{`! Access Pausing: ${getFormattedDate(attestationByUtc, DATE_TEXT_FORMAT)}`}</div>
       );
       break;
-    // TODO: add state === EXPIRED case before ableToRenew case (https://github.com/icgc-argo/dac-ui/issues/505)
+    case state === ApplicationState.EXPIRED:
+      return (
+        <div
+          css={(theme) => css`
+            color: ${theme.colors.error};
+          `}
+        >
+          {`! Access Expired: ${getFormattedDate(expiresAtUtc, DATE_TEXT_FORMAT)}`}
+        </div>
+      );
+      break;
     // ableToRenew becomes false once a renewal is created, but we still want to display the "Expiring" text state
     case ableToRenew || (renewalAppId && state === ApplicationState.APPROVED):
       return (
@@ -115,6 +125,7 @@ const getStatusDate = (application: ApplicationSummary): any => {
       return null;
   }
 };
+
 const InProgress = ({ application }: { application: ApplicationSummary }) => {
   const theme = useTheme();
   const { NEXT_PUBLIC_DACO_SURVEY_URL } = getConfig();
@@ -135,9 +146,12 @@ const InProgress = ({ application }: { application: ApplicationSummary }) => {
 
   const statusDate = getStatusDate(application);
 
+  // TODO: an application that is past the renewal period and has no renewalAppId (no renewal has been created) will show in default text colour
   const statusError =
-    isAttestable || ableToRenew || (renewalAppId && state === ApplicationState.APPROVED);
-  state === ApplicationState.PAUSED ||
+    isAttestable ||
+    ableToRenew ||
+    (renewalAppId && [ApplicationState.APPROVED, ApplicationState.EXPIRED].includes(state)) ||
+    state === ApplicationState.PAUSED ||
     (revisionsRequested &&
       [ApplicationState.REVISIONS_REQUESTED, ApplicationState.SIGN_AND_SUBMIT].includes(state));
 

--- a/global/utils/dates/helpers.ts
+++ b/global/utils/dates/helpers.ts
@@ -1,0 +1,15 @@
+import { addDays, isAfter } from 'date-fns';
+
+// calculate the last day an app can be renewed, expiry + configured days post expiry
+// DACO allows 90 days after expiry to renew
+export const getRenewalPeriodEndDate = (expiryDate: string): string => {
+  const expiry = new Date(expiryDate);
+  // TODO: Get rid of hardcoded num days. Can the configured days after expiry be retrieved from the BE?
+  return addDays(expiry, 90).toDateString();
+};
+
+export const isRenewalPeriodEnded = (expiryDate: string): boolean => {
+  const now = new Date();
+  const endDate = new Date(getRenewalPeriodEndDate(expiryDate));
+  return isAfter(now, endDate);
+};


### PR DESCRIPTION
Styles, text content and buttons for EXPIRED app dashboard cards, including expired while still in renewal period and expired after renewal period ends
- also creates dates util folder for date-specific custom functions. Will move existing constants/helper functions to this folder in a separate PR!