### PR TITLE
💄 506 - renewal app card

### DIFF
--- a/components/pages/Applications/Dashboard/Applications/InProgress/helpers.ts
+++ b/components/pages/Applications/Dashboard/Applications/InProgress/helpers.ts
@@ -34,6 +34,9 @@ export const getStatusText = (application: ApplicationSummary) => {
     revisionsRequested,
     ableToRenew,
     renewalAppId,
+    isRenewal,
+    renewalPeriodEndDateUtc,
+    sourceAppId,
   } = application;
   const dates: StatusDates = {
     lastUpdatedAtUtc,
@@ -48,7 +51,7 @@ export const getStatusText = (application: ApplicationSummary) => {
       'expiresAtUtc',
     ]),
   };
-  const formatStatusDate = (date: string) =>
+  const formatStatusDate = (date?: string) =>
     formatDate(new Date(date || dates.lastUpdatedAtUtc), DATE_TEXT_FORMAT);
 
   const revisionsRequestedText = `Reopened for revisions on ${formatStatusDate(
@@ -73,9 +76,24 @@ export const getStatusText = (application: ApplicationSummary) => {
             dates.approvedAtUtc,
           )}. You now have access to ICGC Controlled Data.`;
     case ApplicationState.SIGN_AND_SUBMIT:
-      return revisionsRequested ? revisionsRequestedText : createdOnText;
+      // TODO: any need to differentiate a renewal with revisions vs a new app with revisions?
+      return revisionsRequested
+        ? revisionsRequestedText
+        : isRenewal
+        ? `Renewal created on ${formatStatusDate(
+            dates.createdAtUtc,
+          )} from ${sourceAppId}. Please submit this application for review by ${formatStatusDate(
+            renewalPeriodEndDateUtc,
+          )} to extend your access for another two years.`
+        : createdOnText;
     case ApplicationState.DRAFT:
-      return createdOnText;
+      return isRenewal
+        ? `Renewal created on ${formatStatusDate(
+            dates.createdAtUtc,
+          )} from ${sourceAppId}. Please submit this application for review by ${formatStatusDate(
+            renewalPeriodEndDateUtc,
+          )} to extend your access for another two years.`
+        : createdOnText;
     case ApplicationState.REVIEW:
       return `Submitted on ${formatStatusDate(
         dates.submittedAtUtc,

--- a/components/pages/Applications/Dashboard/Applications/InProgress/helpers.ts
+++ b/components/pages/Applications/Dashboard/Applications/InProgress/helpers.ts
@@ -24,7 +24,11 @@ import { ApplicationState } from 'components/ApplicationProgressBar/types';
 import { ApplicationSummary } from 'components/pages/Applications/types';
 import { DateFormat } from 'global/utils/dates/types';
 import { StatusDates } from '.';
-import { getFormattedDate, getRenewalPeriodEndDate, isRenewalPeriodEnded } from 'global/utils/dates/helpers';
+import {
+  getFormattedDate,
+  getRenewalPeriodEndDate,
+  isRenewalPeriodEnded,
+} from 'global/utils/dates/helpers';
 
 export const getStatusText = (application: ApplicationSummary) => {
   const {
@@ -55,7 +59,9 @@ export const getStatusText = (application: ApplicationSummary) => {
   const formatStatusDate = (date: string) =>
     formatDate(new Date(date || dates.lastUpdatedAtUtc), DateFormat.DATE_TEXT_FORMAT);
 
-  const revisionsRequestedText = `Reopened for revisions on ${formatStatusDate(
+  const revisionsRequestedText = `${
+    isRenewal ? 'Renewal reopened' : 'Reopened'
+  } for revisions on ${formatStatusDate(
     dates.lastUpdatedAtUtc,
   )}. Revision details were sent via email.`;
   const createdOnText = `Created on ${formatStatusDate(dates.createdAtUtc)}.`;
@@ -63,9 +69,9 @@ export const getStatusText = (application: ApplicationSummary) => {
   switch (state) {
     case ApplicationState.APPROVED:
       const approvedAppRenewalEndDate = getFormattedDate(
-            getRenewalPeriodEndDate(dates.expiresAtUtc),
-            DateFormat.DATE_TEXT_FORMAT,
-          );
+        getRenewalPeriodEndDate(dates.expiresAtUtc),
+        DateFormat.DATE_TEXT_FORMAT,
+      );
       return isAttestable
         ? `An annual attestation is required for this application. Access for this project team will be paused on ${getFormattedDate(
             dates.attestationByUtc,
@@ -79,23 +85,26 @@ export const getStatusText = (application: ApplicationSummary) => {
             dates.approvedAtUtc,
           )}. You now have access to ICGC Controlled Data.`;
     case ApplicationState.SIGN_AND_SUBMIT:
-      // TODO: any need to differentiate a renewal with revisions vs a new app with revisions?
       return revisionsRequested
         ? revisionsRequestedText
         : isRenewal
         ? `Renewal created on ${formatStatusDate(
             dates.createdAtUtc,
-          )} from ${sourceAppId}. Please submit this application for review by ${formatStatusDate(
-            renewalPeriodEndDateUtc,
-          )} to extend your access for another two years.`
+          )} from ${sourceAppId}. Please submit this application for review ${
+            renewalPeriodEndDateUtc
+              ? `by ${getFormattedDate(renewalPeriodEndDateUtc, DateFormat.DATE_TEXT_FORMAT)}`
+              : ''
+          } to extend your access for another two years.`
         : createdOnText;
     case ApplicationState.DRAFT:
       return isRenewal
         ? `Renewal created on ${formatStatusDate(
             dates.createdAtUtc,
-          )} from ${sourceAppId}. Please submit this application for review by ${formatStatusDate(
-            renewalPeriodEndDateUtc,
-          )} to extend your access for another two years.`
+          )} from ${sourceAppId}. Please submit this application for review ${
+            renewalPeriodEndDateUtc
+              ? `by ${getFormattedDate(renewalPeriodEndDateUtc, DateFormat.DATE_TEXT_FORMAT)}`
+              : ''
+          } to extend your access for another two years.`
         : createdOnText;
     case ApplicationState.REVIEW:
       return `Submitted on ${formatStatusDate(

--- a/components/pages/Applications/Dashboard/Applications/InProgress/index.tsx
+++ b/components/pages/Applications/Dashboard/Applications/InProgress/index.tsx
@@ -33,6 +33,7 @@ import { ApplicationSummary } from 'components/pages/Applications/types';
 
 import { getConfig } from 'global/config';
 import { getFormattedDate, isRenewalPeriodEnded } from 'global/utils/dates/helpers';
+import { parseISO } from 'date-fns';
 
 export interface StatusDates {
   lastUpdatedAtUtc: string;
@@ -58,6 +59,8 @@ const getStatusDate = (application: ApplicationSummary): any => {
     lastPausedAtUtc,
     renewalAppId,
     expiredEventDateUtc,
+    sourceAppId,
+    renewalPeriodEndDateUtc,
   } = application;
   switch (true) {
     case state === ApplicationState.PAUSED:
@@ -109,6 +112,29 @@ const getStatusDate = (application: ApplicationSummary): any => {
           `}
         >{`! Access Expiring: ${getFormattedDate(expiresAtUtc, DateFormat.DATE_TEXT_FORMAT)}`}</div>
       );
+      break;
+    // TODO: discuss if this status date is necessary and, if so, what should the text be?
+    case !!sourceAppId &&
+      [
+        ApplicationState.DRAFT,
+        ApplicationState.SIGN_AND_SUBMIT,
+        ApplicationState.REVISIONS_REQUESTED,
+      ].includes(state):
+      if (
+        renewalPeriodEndDateUtc &&
+        parseISO(renewalPeriodEndDateUtc).toString() !== 'Invalid Date'
+      ) {
+        return (
+          <div
+            css={(theme) => css`
+              color: ${theme.colors.error};
+            `}
+          >{`! Renewal Expiring: ${getFormattedDate(
+            renewalPeriodEndDateUtc,
+            DateFormat.DATE_TEXT_FORMAT,
+          )}`}</div>
+        );
+      }
       break;
     case expiresAtUtc && !closedAtUtc:
       return (

--- a/components/pages/Applications/Dashboard/Applications/InProgress/index.tsx
+++ b/components/pages/Applications/Dashboard/Applications/InProgress/index.tsx
@@ -144,6 +144,7 @@ const InProgress = ({ application }: { application: ApplicationSummary }) => {
     ableToRenew,
     renewalAppId,
     expiresAtUtc,
+    isRenewal,
   } = application;
 
   const statusDate = getStatusDate(application);
@@ -157,7 +158,8 @@ const InProgress = ({ application }: { application: ApplicationSummary }) => {
       !renewalPeriodEnded) ||
     state === ApplicationState.PAUSED ||
     (revisionsRequested &&
-      [ApplicationState.REVISIONS_REQUESTED, ApplicationState.SIGN_AND_SUBMIT].includes(state));
+      [ApplicationState.REVISIONS_REQUESTED, ApplicationState.SIGN_AND_SUBMIT].includes(state)) ||
+    (isRenewal && [ApplicationState.DRAFT, ApplicationState.SIGN_AND_SUBMIT].includes(state));
 
   const showReport =
     (state === ApplicationState.EXPIRED && renewalPeriodEnded) ||

--- a/components/pages/Applications/types.ts
+++ b/components/pages/Applications/types.ts
@@ -116,6 +116,8 @@ export type ApplicationSummary = {
   isRenewal: boolean;
   ableToRenew: boolean;
   renewalAppId?: string;
+  sourceAppId?: string;
+  renewalPeriodEndDateUtc?: string;
 };
 
 export type ApplicationDataByField = {


### PR DESCRIPTION
Adds custom text/status for renewal cards in `DRAFT`, `SIGN AND SUBMIT` or `REVISIONS REQUESTED`
Adds status date as well, but need to decide what the display text should be.