### PR TITLE
💬 653 - Add System DacoRole, app history display text

### DIFF
--- a/components/pages/Applications/ApplicationForm/Forms/ApplicationHistoryModal.tsx
+++ b/components/pages/Applications/ApplicationForm/Forms/ApplicationHistoryModal.tsx
@@ -45,6 +45,8 @@ const columns = [
     Cell: ({ original }: { original: UserViewApplicationUpdate }) =>
       original.author.role === DacoRole.ADMIN
         ? 'DACO Administrator'
+        : original.author.role === DacoRole.SYSTEM
+        ? 'DACO System'
         : capitalize(original.author.role),
   },
 ];

--- a/components/pages/Applications/ApplicationForm/Forms/types.ts
+++ b/components/pages/Applications/ApplicationForm/Forms/types.ts
@@ -337,6 +337,7 @@ export enum DOCUMENT_TYPES {
 export enum DacoRole {
   SUBMITTER = 'SUBMITTER',
   ADMIN = 'ADMIN',
+  SYSTEM = 'SYSTEM',
 }
 
 type UpdateAuthor = {


### PR DESCRIPTION
Display `SYSTEM` role in application history modal as `DACO System` for clarity.
- add `SYSTEM` DacoRole enum