### PR TITLE
♻️ Refactor date formatters

### DIFF
--- a/components/pages/Applications/ApplicationForm/Forms/ApplicationHistoryModal.tsx
+++ b/components/pages/Applications/ApplicationForm/Forms/ApplicationHistoryModal.tsx
@@ -7,20 +7,21 @@ import { capitalize, startCase } from 'lodash';
 import urlJoin from 'url-join';
 import Banner from '@icgc-argo/uikit/notifications/Banner';
 import { AxiosResponse, AxiosError } from 'axios';
-import { format } from 'date-fns';
 
 import { ModalPortal } from 'components/Root';
 import { useAuthContext } from 'global/hooks';
 import { API } from 'global/constants';
 import { DacoRole, UpdateEvent, UserViewApplicationUpdate } from './types';
-import { DATE_RANGE_DISPLAY_FORMAT } from 'global/utils/dates/constants';
+import { DateFormat } from 'global/utils/dates/types';
+import { getFormattedDate } from 'global/utils/dates/helpers';
 
 const columns = [
   {
     accessor: 'date',
     Header: 'Date of Status Change',
-    Cell: ({ original }: { original: UserViewApplicationUpdate }) =>
-      format(new Date(original.date), DATE_RANGE_DISPLAY_FORMAT),
+    Cell: ({ original }: { original: UserViewApplicationUpdate }) => {
+      return getFormattedDate(original.date, DateFormat.DATE_RANGE_DISPLAY_FORMAT);
+    },
   },
   {
     accessor: 'eventType',

--- a/components/pages/Applications/ApplicationForm/Forms/ApplicationHistoryModal.tsx
+++ b/components/pages/Applications/ApplicationForm/Forms/ApplicationHistoryModal.tsx
@@ -11,8 +11,9 @@ import { format } from 'date-fns';
 
 import { ModalPortal } from 'components/Root';
 import { useAuthContext } from 'global/hooks';
-import { API, DATE_RANGE_DISPLAY_FORMAT } from 'global/constants';
+import { API } from 'global/constants';
 import { DacoRole, UpdateEvent, UserViewApplicationUpdate } from './types';
+import { DATE_RANGE_DISPLAY_FORMAT } from 'global/utils/dates/constants';
 
 const columns = [
   {

--- a/components/pages/Applications/ApplicationForm/Forms/EthicsLetter/UploadsTable.tsx
+++ b/components/pages/Applications/ApplicationForm/Forms/EthicsLetter/UploadsTable.tsx
@@ -20,7 +20,6 @@
 import { createRef, ReactElement, useEffect, useState } from 'react';
 import { css } from '@emotion/core';
 import { AxiosError } from 'axios';
-import { format } from 'date-fns';
 
 import { UikitTheme } from '@icgc-argo/uikit/index';
 import Button from '@icgc-argo/uikit/Button';
@@ -51,7 +50,8 @@ import { CustomLoadingButton } from '../common';
 import Banner from '@icgc-argo/uikit/notifications/Banner';
 import { useToaster } from 'global/hooks/useToaster';
 import { TOAST_VARIANTS } from '@icgc-argo/uikit/notifications/Toast';
-import { DATE_RANGE_DISPLAY_FORMAT } from 'global/utils/dates/constants';
+import { DateFormat } from 'global/utils/dates/types';
+import { getFormattedDate } from 'global/utils/dates/helpers';
 
 const VALID_FILE_TYPE = [
   'application/msword',
@@ -353,7 +353,7 @@ const UploadsTable = ({
               {
                 accessor: 'uploadedAtUtc',
                 Cell: ({ value }: { value: string }) =>
-                  format(new Date(value), DATE_RANGE_DISPLAY_FORMAT),
+                  getFormattedDate(value, DateFormat.DATE_RANGE_DISPLAY_FORMAT),
                 Header: 'Uploaded On',
               },
               ...(isRequiredPostApproval

--- a/components/pages/Applications/ApplicationForm/Forms/EthicsLetter/UploadsTable.tsx
+++ b/components/pages/Applications/ApplicationForm/Forms/EthicsLetter/UploadsTable.tsx
@@ -34,7 +34,7 @@ import { useTheme } from '@icgc-argo/uikit/ThemeProvider';
 import Modal from '@icgc-argo/uikit/Modal';
 import { BANNER_VARIANTS } from '@icgc-argo/uikit/notifications/Banner';
 
-import { API, DATE_RANGE_DISPLAY_FORMAT } from 'global/constants';
+import { API } from 'global/constants';
 import { useAuthContext } from 'global/hooks';
 import { ModalPortal } from 'components/Root';
 
@@ -51,6 +51,7 @@ import { CustomLoadingButton } from '../common';
 import Banner from '@icgc-argo/uikit/notifications/Banner';
 import { useToaster } from 'global/hooks/useToaster';
 import { TOAST_VARIANTS } from '@icgc-argo/uikit/notifications/Toast';
+import { DATE_RANGE_DISPLAY_FORMAT } from 'global/utils/dates/constants';
 
 const VALID_FILE_TYPE = [
   'application/msword',

--- a/components/pages/Applications/ApplicationForm/Forms/Signature.tsx
+++ b/components/pages/Applications/ApplicationForm/Forms/Signature.tsx
@@ -34,7 +34,7 @@ import {
   FormSectionValidationState_Signature,
   FormValidationStateParameters,
 } from './types';
-import { UPLOAD_DATE_FORMAT } from '../../Dashboard/Applications/InProgress/constants';
+import { UPLOAD_DATE_FORMAT } from 'global/utils/dates/constants';
 import { getFormattedDate } from '../../Dashboard/Applications/InProgress/helpers';
 import { API, APPLICATIONS_PATH, SUBMISSION_SUCCESS_CHECK } from 'global/constants';
 import { useAuthContext } from 'global/hooks';

--- a/components/pages/Applications/ApplicationForm/Forms/Signature.tsx
+++ b/components/pages/Applications/ApplicationForm/Forms/Signature.tsx
@@ -25,27 +25,28 @@ import Icon from '@icgc-argo/uikit/Icon';
 import { useTheme } from '@icgc-argo/uikit/ThemeProvider';
 import Typography from '@icgc-argo/uikit/Typography';
 import React, { ReactElement, useState } from 'react';
-import FormFieldHelpBubble from './FormFieldHelpBubble';
-import { RequiredStar } from './RequiredFieldsMessage';
+import router from 'next/router';
 import { styled } from '@icgc-argo/uikit';
 import { AxiosError } from 'axios';
+import urlJoin from 'url-join';
+import Modal from '@icgc-argo/uikit/Modal';
+import Link from '@icgc-argo/uikit/Link';
+
+import FormFieldHelpBubble from './FormFieldHelpBubble';
+import { RequiredStar } from './RequiredFieldsMessage';
 import {
   DOCUMENT_TYPES,
   FormSectionValidationState_Signature,
   FormValidationStateParameters,
 } from './types';
-import { UPLOAD_DATE_FORMAT } from 'global/utils/dates/constants';
-import { getFormattedDate } from '../../Dashboard/Applications/InProgress/helpers';
+import { DateFormat } from 'global/utils/dates/types';
+import { getFormattedDate } from 'global/utils/dates/helpers';
 import { API, APPLICATIONS_PATH, SUBMISSION_SUCCESS_CHECK } from 'global/constants';
 import { useAuthContext } from 'global/hooks';
-import Modal from '@icgc-argo/uikit/Modal';
 import { ModalPortal } from 'components/Root';
-import Link from '@icgc-argo/uikit/Link';
 import { CustomLoadingButton, generatePDFDocument } from './common';
-import urlJoin from 'url-join';
 import { ApplicationState } from '../../types';
 import { getStaticComponents, UITitle } from '../../PDF/common';
-import router from 'next/router';
 
 const FormControl = styled(Control)`
   display: flex;
@@ -345,7 +346,8 @@ const Signature = ({
                     >
                       |
                     </span>{' '}
-                    Uploaded on: {getFormattedDate(uploadedAtUtc.value, UPLOAD_DATE_FORMAT)}
+                    Uploaded on:{' '}
+                    {getFormattedDate(uploadedAtUtc.value, DateFormat.UPLOAD_DATE_FORMAT)}
                   </>
                 )}
                 {!isSectionDisabled && (

--- a/components/pages/Applications/ApplicationForm/Forms/common.tsx
+++ b/components/pages/Applications/ApplicationForm/Forms/common.tsx
@@ -18,7 +18,7 @@
  */
 
 import { pdf, Document } from '@react-pdf/renderer';
-import { FILE_DATE_FORMAT } from '../../Dashboard/Applications/InProgress/constants';
+import { FILE_DATE_FORMAT } from 'global/utils/dates/constants';
 import { getFormattedDate } from '../../Dashboard/Applications/InProgress/helpers';
 import Cover from '../../PDF/Cover';
 import Signatures from '../../PDF/Signatures';

--- a/components/pages/Applications/ApplicationForm/Forms/common.tsx
+++ b/components/pages/Applications/ApplicationForm/Forms/common.tsx
@@ -18,8 +18,8 @@
  */
 
 import { pdf, Document } from '@react-pdf/renderer';
-import { FILE_DATE_FORMAT } from 'global/utils/dates/constants';
-import { getFormattedDate } from '../../Dashboard/Applications/InProgress/helpers';
+import { DateFormat } from 'global/utils/dates/types';
+import { getFormattedDate } from 'global/utils/dates/helpers';
 import Cover from '../../PDF/Cover';
 import Signatures from '../../PDF/Signatures';
 import StaticAppendices from '../../PDF/StaticAppendices';
@@ -55,7 +55,7 @@ export const generatePDFDocument = async (data: ApplicationData) => {
     </Document>,
   ).toBlob();
 
-  const dateCreated = getFormattedDate(Date.now(), FILE_DATE_FORMAT);
+  const dateCreated = getFormattedDate(Date.now(), DateFormat.FILE_DATE_FORMAT);
   saveAs(blob, `${data.appId}-${dateCreated}`);
 };
 

--- a/components/pages/Applications/ApplicationForm/Forms/index.tsx
+++ b/components/pages/Applications/ApplicationForm/Forms/index.tsx
@@ -45,7 +45,7 @@ import Link from '@icgc-argo/uikit/Link';
 import ApplicationHistoryModal from './ApplicationHistoryModal';
 import { SetLastUpdated } from '../types';
 import { format } from 'date-fns';
-import { DATE_TEXT_FORMAT } from 'global/constants';
+import { DATE_TEXT_FORMAT } from 'global/utils/dates/constants';
 
 import { AxiosError } from 'axios';
 import { useAuthContext } from 'global/hooks';

--- a/components/pages/Applications/ApplicationForm/Forms/index.tsx
+++ b/components/pages/Applications/ApplicationForm/Forms/index.tsx
@@ -44,13 +44,13 @@ import { getConfig } from 'global/config';
 import Link from '@icgc-argo/uikit/Link';
 import ApplicationHistoryModal from './ApplicationHistoryModal';
 import { SetLastUpdated } from '../types';
-import { format } from 'date-fns';
-import { DATE_TEXT_FORMAT } from 'global/utils/dates/constants';
+import { DateFormat } from 'global/utils/dates/types';
 
 import { AxiosError } from 'axios';
 import { useAuthContext } from 'global/hooks';
 import urlJoin from 'url-join';
 import { API, APPLICATIONS_PATH } from 'global/constants';
+import { getFormattedDate } from 'global/utils/dates/helpers';
 
 enum VisibleModalOption {
   NONE = 'NONE',
@@ -224,9 +224,9 @@ const ApplicationFormsBase = ({
                   margin-left: 10px;
                 `}
               >
-                {`Annual Attestation is required by ${format(
-                  new Date(attestationByUtc),
-                  DATE_TEXT_FORMAT,
+                {`Annual Attestation is required by ${getFormattedDate(
+                  attestationByUtc,
+                  DateFormat.DATE_TEXT_FORMAT,
                 )} or access will be paused`}
               </div>
             }

--- a/components/pages/Applications/ApplicationForm/Header/Details.tsx
+++ b/components/pages/Applications/ApplicationForm/Header/Details.tsx
@@ -21,10 +21,11 @@ import { ReactElement } from 'react';
 import { css } from '@icgc-argo/uikit';
 import Link from '@icgc-argo/uikit/Link';
 import Typography from '@icgc-argo/uikit/Typography';
-import { APPLICATIONS_PATH, DATE_TEXT_FORMAT } from 'global/constants';
+import { APPLICATIONS_PATH } from 'global/constants';
 import { useTheme } from '@icgc-argo/uikit/ThemeProvider';
 import { ApplicationAccessInfo } from '.';
 import { format, parseISO } from 'date-fns';
+import { DATE_TEXT_FORMAT } from 'global/utils/dates/constants';
 
 const isValidDate = (val?: any): boolean => {
   try {

--- a/components/pages/Applications/ApplicationForm/Header/Details.tsx
+++ b/components/pages/Applications/ApplicationForm/Header/Details.tsx
@@ -24,18 +24,8 @@ import Typography from '@icgc-argo/uikit/Typography';
 import { APPLICATIONS_PATH } from 'global/constants';
 import { useTheme } from '@icgc-argo/uikit/ThemeProvider';
 import { ApplicationAccessInfo } from '.';
-import { format, parseISO } from 'date-fns';
-import { DATE_TEXT_FORMAT } from 'global/utils/dates/constants';
-
-const isValidDate = (val?: any): boolean => {
-  try {
-    parseISO(val);
-    return true;
-  } catch (e) {
-    console.warn(e);
-    return false;
-  }
-};
+import { DateFormat } from 'global/utils/dates/types';
+import { getFormattedDate } from 'global/utils/dates/helpers';
 
 const ApplicationAccessInfoDisplay = ({ date, isWarning, status }: ApplicationAccessInfo) => {
   const theme = useTheme();
@@ -48,7 +38,7 @@ const ApplicationAccessInfoDisplay = ({ date, isWarning, status }: ApplicationAc
           color: ${theme.colors[isWarning ? 'error' : 'secondary']};
         `}
       >
-        {`${status}: ${date && isValidDate(date) ? format(new Date(date), DATE_TEXT_FORMAT) : ''}`}
+        {`${status}: ${date ? getFormattedDate(date, DateFormat.DATE_TEXT_FORMAT) : ''}`}
       </span>
     </>
   );

--- a/components/pages/Applications/ApplicationForm/Header/index.tsx
+++ b/components/pages/Applications/ApplicationForm/Header/index.tsx
@@ -22,7 +22,7 @@ import { format } from 'date-fns';
 import { css } from '@icgc-argo/uikit';
 import { UikitTheme } from '@icgc-argo/uikit/index';
 import PageHeader from 'components/PageHeader';
-import { DATE_TEXT_FORMAT } from 'global/utils/dates/constants';
+import { DateFormat } from 'global/utils/dates/types';
 import Actions from './Actions';
 import Details from './Details';
 import Progress from './Progress';
@@ -30,6 +30,7 @@ import { RefetchDataFunction } from '../Forms/types';
 import { ApplicationState } from 'components/ApplicationProgressBar/types';
 import { ApplicationData } from '../../types';
 import { isPastExpiry } from '../Forms/helpers';
+import { getFormattedDate } from 'global/utils/dates/helpers';
 
 export type ApplicationAccessInfo = { date?: string; isWarning: boolean; status: string };
 
@@ -133,8 +134,11 @@ const ApplicationHeader = ({
         <Details
           appId={appId}
           applicant={applicant}
-          createdAt={format(new Date(createdAtUtc), DATE_TEXT_FORMAT)}
-          lastUpdated={format(new Date(lastUpdatedAtUtc), DATE_TEXT_FORMAT + ' h:mm aaaa')}
+          createdAt={getFormattedDate(createdAtUtc, DateFormat.DATE_TEXT_FORMAT)}
+          lastUpdated={format(
+            new Date(lastUpdatedAtUtc),
+            DateFormat.DATE_TEXT_FORMAT + ' h:mm aaaa',
+          )}
           accessInfo={accessInfo}
         />
 

--- a/components/pages/Applications/ApplicationForm/Header/index.tsx
+++ b/components/pages/Applications/ApplicationForm/Header/index.tsx
@@ -56,6 +56,7 @@ const ApplicationHeader = ({
     attestationByUtc,
     lastPausedAtUtc,
     ableToRenew,
+    expiredEventDateUtc,
   } = data;
 
   const applicant = `${displayName}${primaryAffiliation ? `. ${primaryAffiliation}` : ''}`;
@@ -81,7 +82,7 @@ const ApplicationHeader = ({
         };
       case state === ApplicationState.EXPIRED:
         return {
-          date: expiresAtUtc,
+          date: expiredEventDateUtc || expiresAtUtc,
           isWarning: true,
           status: 'Expired',
         };

--- a/components/pages/Applications/ApplicationForm/Header/index.tsx
+++ b/components/pages/Applications/ApplicationForm/Header/index.tsx
@@ -136,6 +136,7 @@ const ApplicationHeader = ({
           appId={appId}
           applicant={applicant}
           createdAt={getFormattedDate(createdAtUtc, DateFormat.DATE_TEXT_FORMAT)}
+          // using format() here because DATE_TEXT_FORMAT + ' h:mm aaaa' was not added as a DateFormat enum, may be removed/replaced by TIME_AND_DATE_FORMAT
           lastUpdated={format(
             new Date(lastUpdatedAtUtc),
             DateFormat.DATE_TEXT_FORMAT + ' h:mm aaaa',

--- a/components/pages/Applications/ApplicationForm/Header/index.tsx
+++ b/components/pages/Applications/ApplicationForm/Header/index.tsx
@@ -22,7 +22,7 @@ import { format } from 'date-fns';
 import { css } from '@icgc-argo/uikit';
 import { UikitTheme } from '@icgc-argo/uikit/index';
 import PageHeader from 'components/PageHeader';
-import { DATE_TEXT_FORMAT } from 'global/constants';
+import { DATE_TEXT_FORMAT } from 'global/utils/dates/constants';
 import Actions from './Actions';
 import Details from './Details';
 import Progress from './Progress';

--- a/components/pages/Applications/ApplicationForm/RequestRevisionsBar/ApproveModal.tsx
+++ b/components/pages/Applications/ApplicationForm/RequestRevisionsBar/ApproveModal.tsx
@@ -30,7 +30,8 @@ import FormControl from '@icgc-argo/uikit/form/FormControl';
 import FormHelperText from '@icgc-argo/uikit/form/FormHelperText';
 
 import { useAuthContext } from 'global/hooks';
-import { API, DATE_TEXT_FORMAT } from 'global/constants';
+import { API } from 'global/constants';
+import { DATE_TEXT_FORMAT } from 'global/utils/dates/constants';
 
 const ApproveModal = ({
   appId,

--- a/components/pages/Applications/ApplicationForm/RequestRevisionsBar/ApproveModal.tsx
+++ b/components/pages/Applications/ApplicationForm/RequestRevisionsBar/ApproveModal.tsx
@@ -20,7 +20,7 @@
 import { useState } from 'react';
 import { AxiosError } from 'axios';
 import urlJoin from 'url-join';
-import { add, format } from 'date-fns';
+import { add } from 'date-fns';
 import { css } from '@emotion/core';
 import router from 'next/router';
 
@@ -31,7 +31,8 @@ import FormHelperText from '@icgc-argo/uikit/form/FormHelperText';
 
 import { useAuthContext } from 'global/hooks';
 import { API } from 'global/constants';
-import { DATE_TEXT_FORMAT } from 'global/utils/dates/constants';
+import { DateFormat } from 'global/utils/dates/types';
+import { getFormattedDate } from 'global/utils/dates/helpers';
 
 const ApproveModal = ({
   appId,
@@ -43,8 +44,8 @@ const ApproveModal = ({
   primaryAffiliation: string;
 }) => {
   const currentDate = new Date();
-  const startDate = format(currentDate, DATE_TEXT_FORMAT);
-  const endDate = format(add(currentDate, { years: 2 }), DATE_TEXT_FORMAT);
+  const startDate = getFormattedDate(currentDate, DateFormat.DATE_TEXT_FORMAT);
+  const endDate = getFormattedDate(add(currentDate, { years: 2 }), DateFormat.DATE_TEXT_FORMAT);
 
   const [error, setError] = useState<AxiosError | undefined>(undefined);
   const [isLoading, setIsLoading] = useState<boolean>(false);

--- a/components/pages/Applications/ApplicationForm/RequestRevisionsBar/PDFActions.tsx
+++ b/components/pages/Applications/ApplicationForm/RequestRevisionsBar/PDFActions.tsx
@@ -29,11 +29,11 @@ import { useState } from 'react';
 import { ApprovedDoc } from '../../types';
 import { CustomLoadingButton } from '../Forms/common';
 import { DOCUMENT_TYPES } from '../Forms/types';
-import { format as formatDate } from 'date-fns';
-import { API_DEFAULT_DATE_FORMAT } from 'global/utils/dates/constants';
+import { DateFormat } from 'global/utils/dates/types';
 import { SetLastUpdated } from '../types';
 import { css } from '@icgc-argo/uikit';
 import Typography from '@icgc-argo/uikit/Typography';
+import { getFormattedDate } from 'global/utils/dates/helpers';
 
 const PDFActions = ({
   appId,
@@ -64,7 +64,7 @@ const PDFActions = ({
     })
       .then(() => {
         setIsDeleting(false);
-        const d = formatDate(new Date(), API_DEFAULT_DATE_FORMAT);
+        const d = getFormattedDate(new Date(), DateFormat.API_DEFAULT_DATE_FORMAT);
         setLastUpdated(d);
       })
       .catch((err: AxiosError) => {
@@ -98,7 +98,7 @@ const PDFActions = ({
         url={`${API.APPLICATIONS}/${appId}/assets/${DOCUMENT_TYPES.APPROVED_PDF}/upload`}
         onUpload={() => {
           setUploadError(false);
-          setLastUpdated(formatDate(new Date(), API_DEFAULT_DATE_FORMAT));
+          setLastUpdated(getFormattedDate(new Date(), DateFormat.API_DEFAULT_DATE_FORMAT));
         }}
         onUploadError={() => setUploadError(true)}
         validators={[pdfValidator]}

--- a/components/pages/Applications/ApplicationForm/RequestRevisionsBar/PDFActions.tsx
+++ b/components/pages/Applications/ApplicationForm/RequestRevisionsBar/PDFActions.tsx
@@ -30,7 +30,7 @@ import { ApprovedDoc } from '../../types';
 import { CustomLoadingButton } from '../Forms/common';
 import { DOCUMENT_TYPES } from '../Forms/types';
 import { format as formatDate } from 'date-fns';
-import { API_DEFAULT_DATE_FORMAT } from '../../Dashboard/Applications/InProgress/constants';
+import { API_DEFAULT_DATE_FORMAT } from 'global/utils/dates/constants';
 import { SetLastUpdated } from '../types';
 import { css } from '@icgc-argo/uikit';
 import Typography from '@icgc-argo/uikit/Typography';

--- a/components/pages/Applications/Dashboard/Applications/CollaboratorApplication/index.tsx
+++ b/components/pages/Applications/Dashboard/Applications/CollaboratorApplication/index.tsx
@@ -3,8 +3,8 @@ import Table from '@icgc-argo/uikit/Table';
 import { IndividualInfo } from 'components/pages/Applications/types';
 import { createRef } from 'react';
 import DashboardCard from '../../Card';
-import { UPLOAD_DATE_FORMAT } from 'global/utils/dates/constants';
-import { getFormattedDate } from '../InProgress/helpers';
+import { DateFormat } from 'global/utils/dates/types';
+import { getFormattedDate } from 'global/utils/dates/helpers';
 
 const CollaboratorApplication = ({
   data,
@@ -43,7 +43,7 @@ const CollaboratorApplication = ({
             accessor: 'expiresAtUtc',
             Header: 'Access Expiry',
             Cell: ({ value }: { value: string }) => (
-              <span>{getFormattedDate(value, UPLOAD_DATE_FORMAT)}</span>
+              <span>{getFormattedDate(value, DateFormat.UPLOAD_DATE_FORMAT)}</span>
             ),
           },
         ]}

--- a/components/pages/Applications/Dashboard/Applications/CollaboratorApplication/index.tsx
+++ b/components/pages/Applications/Dashboard/Applications/CollaboratorApplication/index.tsx
@@ -3,7 +3,7 @@ import Table from '@icgc-argo/uikit/Table';
 import { IndividualInfo } from 'components/pages/Applications/types';
 import { createRef } from 'react';
 import DashboardCard from '../../Card';
-import { UPLOAD_DATE_FORMAT } from '../InProgress/constants';
+import { UPLOAD_DATE_FORMAT } from 'global/utils/dates/constants';
 import { getFormattedDate } from '../InProgress/helpers';
 
 const CollaboratorApplication = ({

--- a/components/pages/Applications/Dashboard/Applications/InProgress/helpers.ts
+++ b/components/pages/Applications/Dashboard/Applications/InProgress/helpers.ts
@@ -22,7 +22,7 @@ import { format as formatDate } from 'date-fns';
 
 import { ApplicationState } from 'components/ApplicationProgressBar/types';
 import { ApplicationSummary } from 'components/pages/Applications/types';
-import { DATE_TEXT_FORMAT } from 'global/constants';
+import { DATE_TEXT_FORMAT } from 'global/utils/dates/constants';
 import { StatusDates } from '.';
 import { getRenewalPeriodEndDate } from 'global/utils/dates/helpers';
 

--- a/components/pages/Applications/Dashboard/Applications/InProgress/helpers.ts
+++ b/components/pages/Applications/Dashboard/Applications/InProgress/helpers.ts
@@ -22,9 +22,9 @@ import { format as formatDate } from 'date-fns';
 
 import { ApplicationState } from 'components/ApplicationProgressBar/types';
 import { ApplicationSummary } from 'components/pages/Applications/types';
-import { DATE_TEXT_FORMAT } from 'global/utils/dates/constants';
+import { DateFormat } from 'global/utils/dates/types';
 import { StatusDates } from '.';
-import { getRenewalPeriodEndDate } from 'global/utils/dates/helpers';
+import { getFormattedDate, getRenewalPeriodEndDate } from 'global/utils/dates/helpers';
 
 export const getStatusText = (application: ApplicationSummary) => {
   const {
@@ -49,7 +49,7 @@ export const getStatusText = (application: ApplicationSummary) => {
     ]),
   };
   const formatStatusDate = (date: string) =>
-    formatDate(new Date(date || dates.lastUpdatedAtUtc), DATE_TEXT_FORMAT);
+    formatDate(new Date(date || dates.lastUpdatedAtUtc), DateFormat.DATE_TEXT_FORMAT);
 
   const revisionsRequestedText = `Reopened for revisions on ${formatStatusDate(
     dates.lastUpdatedAtUtc,
@@ -59,12 +59,14 @@ export const getStatusText = (application: ApplicationSummary) => {
   switch (state) {
     case ApplicationState.APPROVED:
       return isAttestable
-        ? `An annual attestation is required for this application. Access for this project team will be paused on ${formatStatusDate(
+        ? `An annual attestation is required for this application. Access for this project team will be paused on ${getFormattedDate(
             dates.attestationByUtc,
+            DateFormat.DATE_TEXT_FORMAT,
           )} until you submit your attestation.`
         : ableToRenew || (renewalAppId && state === ApplicationState.APPROVED)
-        ? `Access is expiring soon. To extend your access privileges for another two years, please renew this application by ${formatStatusDate(
+        ? `Access is expiring soon. To extend your access privileges for another two years, please renew this application by ${getFormattedDate(
             getRenewalPeriodEndDate(dates.expiresAtUtc),
+            DateFormat.DATE_TEXT_FORMAT,
           )}.`
         : `Approved on ${formatStatusDate(
             dates.approvedAtUtc,
@@ -92,7 +94,10 @@ export const getStatusText = (application: ApplicationSummary) => {
         dates.lastPausedAtUtc || dates.attestationByUtc,
       )}. Access for this project team will resume once you submit the annual attestation for this application.`;
     case ApplicationState.EXPIRED:
-      const renewalEndDate = formatStatusDate(getRenewalPeriodEndDate(dates.expiresAtUtc));
+      const renewalEndDate = getFormattedDate(
+        getRenewalPeriodEndDate(dates.expiresAtUtc),
+        DateFormat.DATE_TEXT_FORMAT,
+      );
       return ableToRenew
         ? `Access has expired. To extend your access privileges for another two years, please renew this application by ${renewalEndDate}.`
         : renewalAppId
@@ -102,6 +107,3 @@ export const getStatusText = (application: ApplicationSummary) => {
       return '';
   }
 };
-
-export const getFormattedDate = (date: string | number | Date, format: string) =>
-  date ? formatDate(new Date(date), format) : '';

--- a/components/pages/Applications/Dashboard/Applications/InProgress/index.tsx
+++ b/components/pages/Applications/Dashboard/Applications/InProgress/index.tsx
@@ -25,14 +25,14 @@ import Typography from '@icgc-argo/uikit/Typography';
 
 import DashboardCard from '../../Card';
 import ProgressBar from '../../../../../ApplicationProgressBar';
-import { TIME_AND_DATE_FORMAT, DATE_TEXT_FORMAT } from 'global/utils/dates/constants';
-import { getFormattedDate, getStatusText } from './helpers';
+import { DateFormat } from 'global/utils/dates/types';
+import { getStatusText } from './helpers';
 import ButtonGroup from './ButtonGroup';
 import { ApplicationState } from 'components/ApplicationProgressBar/types';
 import { ApplicationSummary } from 'components/pages/Applications/types';
 
 import { getConfig } from 'global/config';
-import { isRenewalPeriodEnded } from 'global/utils/dates/helpers';
+import { getFormattedDate, isRenewalPeriodEnded } from 'global/utils/dates/helpers';
 
 export interface StatusDates {
   lastUpdatedAtUtc: string;
@@ -68,7 +68,7 @@ const getStatusDate = (application: ApplicationSummary): any => {
         >
           {`! Access Paused: ${getFormattedDate(
             lastPausedAtUtc || attestationByUtc,
-            DATE_TEXT_FORMAT,
+            DateFormat.DATE_TEXT_FORMAT,
           )}`}
         </div>
       );
@@ -79,7 +79,10 @@ const getStatusDate = (application: ApplicationSummary): any => {
           css={(theme) => css`
             color: ${theme.colors.error};
           `}
-        >{`! Access Pausing: ${getFormattedDate(attestationByUtc, DATE_TEXT_FORMAT)}`}</div>
+        >{`! Access Pausing: ${getFormattedDate(
+          attestationByUtc,
+          DateFormat.DATE_TEXT_FORMAT,
+        )}`}</div>
       );
       break;
     case state === ApplicationState.EXPIRED:
@@ -89,7 +92,7 @@ const getStatusDate = (application: ApplicationSummary): any => {
             color: ${theme.colors.error};
           `}
         >
-          {`! Access Expired: ${getFormattedDate(expiresAtUtc, DATE_TEXT_FORMAT)}`}
+          {`! Access Expired: ${getFormattedDate(expiresAtUtc, DateFormat.DATE_TEXT_FORMAT)}`}
         </div>
       );
       break;
@@ -100,7 +103,7 @@ const getStatusDate = (application: ApplicationSummary): any => {
           css={(theme) => css`
             color: ${theme.colors.error};
           `}
-        >{`! Access Expiring: ${getFormattedDate(expiresAtUtc, DATE_TEXT_FORMAT)}`}</div>
+        >{`! Access Expiring: ${getFormattedDate(expiresAtUtc, DateFormat.DATE_TEXT_FORMAT)}`}</div>
       );
       break;
     case expiresAtUtc && !closedAtUtc:
@@ -109,7 +112,7 @@ const getStatusDate = (application: ApplicationSummary): any => {
           css={(theme) => css`
             color: ${theme.colors.secondary};
           `}
-        >{`Access Expiry: ${getFormattedDate(expiresAtUtc, DATE_TEXT_FORMAT)}`}</div>
+        >{`Access Expiry: ${getFormattedDate(expiresAtUtc, DateFormat.DATE_TEXT_FORMAT)}`}</div>
       );
       break;
     case !!closedAtUtc && !!approvedAtUtc:
@@ -118,7 +121,7 @@ const getStatusDate = (application: ApplicationSummary): any => {
           css={(theme) => css`
             color: ${theme.colors.error};
           `}
-        >{`Access Expired: ${getFormattedDate(closedAtUtc, DATE_TEXT_FORMAT)}`}</div>
+        >{`Access Expired: ${getFormattedDate(closedAtUtc, DateFormat.DATE_TEXT_FORMAT)}`}</div>
       );
       break;
     default:
@@ -189,7 +192,8 @@ const InProgress = ({ application }: { application: ApplicationSummary }) => {
             </span>
           </div>
           <div>
-            <b>Last Updated:</b> {getFormattedDate(lastUpdatedAtUtc, TIME_AND_DATE_FORMAT)}
+            <b>Last Updated:</b>{' '}
+            {getFormattedDate(lastUpdatedAtUtc, DateFormat.TIME_AND_DATE_FORMAT)}
           </div>
         </Typography>
 

--- a/components/pages/Applications/Dashboard/Applications/InProgress/index.tsx
+++ b/components/pages/Applications/Dashboard/Applications/InProgress/index.tsx
@@ -25,11 +25,10 @@ import Typography from '@icgc-argo/uikit/Typography';
 
 import DashboardCard from '../../Card';
 import ProgressBar from '../../../../../ApplicationProgressBar';
-import { TIME_AND_DATE_FORMAT } from './constants';
+import { TIME_AND_DATE_FORMAT, DATE_TEXT_FORMAT } from 'global/utils/dates/constants';
 import { getFormattedDate, getStatusText } from './helpers';
 import ButtonGroup from './ButtonGroup';
 import { ApplicationState } from 'components/ApplicationProgressBar/types';
-import { DATE_TEXT_FORMAT } from 'global/constants';
 import { ApplicationSummary } from 'components/pages/Applications/types';
 
 import { getConfig } from 'global/config';

--- a/components/pages/Applications/Dashboard/Applications/InProgress/index.tsx
+++ b/components/pages/Applications/Dashboard/Applications/InProgress/index.tsx
@@ -57,6 +57,7 @@ const getStatusDate = (application: ApplicationSummary): any => {
     ableToRenew,
     lastPausedAtUtc,
     renewalAppId,
+    expiredEventDateUtc,
   } = application;
   switch (true) {
     case state === ApplicationState.PAUSED:
@@ -92,7 +93,10 @@ const getStatusDate = (application: ApplicationSummary): any => {
             color: ${theme.colors.error};
           `}
         >
-          {`! Access Expired: ${getFormattedDate(expiresAtUtc, DateFormat.DATE_TEXT_FORMAT)}`}
+          {`! Access Expired: ${getFormattedDate(
+            expiredEventDateUtc || expiresAtUtc,
+            DateFormat.DATE_TEXT_FORMAT,
+          )}`}
         </div>
       );
       break;

--- a/components/pages/Applications/ManageApplications/utils.tsx
+++ b/components/pages/Applications/ManageApplications/utils.tsx
@@ -22,7 +22,7 @@ import { format as formatDate } from 'date-fns';
 import urlJoin from 'url-join';
 import Link from '@icgc-argo/uikit/Link';
 import { TableColumnConfig } from '@icgc-argo/uikit/Table';
-import { DATE_RANGE_DISPLAY_FORMAT } from 'global/constants';
+import { DATE_RANGE_DISPLAY_FORMAT } from 'global/utils/dates/constants';
 import { APPLICATIONS_PATH } from 'global/constants/internalPaths';
 import {
   ApplicationRecord,

--- a/components/pages/Applications/ManageApplications/utils.tsx
+++ b/components/pages/Applications/ManageApplications/utils.tsx
@@ -18,11 +18,10 @@
  */
 
 import { startCase } from 'lodash';
-import { format as formatDate } from 'date-fns';
 import urlJoin from 'url-join';
 import Link from '@icgc-argo/uikit/Link';
 import { TableColumnConfig } from '@icgc-argo/uikit/Table';
-import { DATE_RANGE_DISPLAY_FORMAT } from 'global/utils/dates/constants';
+import { DateFormat } from 'global/utils/dates/types';
 import { APPLICATIONS_PATH } from 'global/constants/internalPaths';
 import {
   ApplicationRecord,
@@ -35,6 +34,7 @@ import { ApplicationState } from 'components/ApplicationProgressBar/types';
 import { css } from '@icgc-argo/uikit';
 import { useTheme } from '@icgc-argo/uikit/ThemeProvider';
 import router from 'next/router';
+import { getFormattedDate } from 'global/utils/dates/helpers';
 
 export const stringifySort = (sortArr: ApplicationsSort[]) =>
   sortArr.map(({ field, order }) => `${field}:${order}`).join(', ');
@@ -141,7 +141,7 @@ export const tableColumns: TableColumnConfig<ApplicationRecord> & {
           `}
         >
           {original.accessExpiry
-            ? formatDate(new Date(original.accessExpiry), DATE_RANGE_DISPLAY_FORMAT)
+            ? getFormattedDate(original.accessExpiry, DateFormat.DATE_RANGE_DISPLAY_FORMAT)
             : null}
         </div>
       );
@@ -153,7 +153,7 @@ export const tableColumns: TableColumnConfig<ApplicationRecord> & {
     accessor: 'lastUpdated',
     Cell: ({ original }: { original: ApplicationRecord }) =>
       original.lastUpdated
-        ? formatDate(new Date(original.lastUpdated), DATE_RANGE_DISPLAY_FORMAT)
+        ? getFormattedDate(original.lastUpdated, DateFormat.DATE_RANGE_DISPLAY_FORMAT)
         : null,
   },
   {

--- a/components/pages/Applications/PDF/Cover.tsx
+++ b/components/pages/Applications/PDF/Cover.tsx
@@ -25,8 +25,8 @@ import PDFIcgcDaco from './icons/PdfIcgcDaco';
 import { getDisplayName, PDFText, PDFTitle } from './common';
 import VerticalTable from './VerticalTable';
 import { ApplicationData } from '../types';
-import { getFormattedDate } from '../Dashboard/Applications/InProgress/helpers';
-import { TIME_DAY_AND_DATE_FORMAT } from 'global/utils/dates/constants';
+import { getFormattedDate } from 'global/utils/dates/helpers';
+import { DateFormat } from 'global/utils/dates/types';
 import { FieldAccessor } from './types';
 
 const styles = StyleSheet.create({
@@ -76,7 +76,7 @@ const Cover = ({ data }: { data?: ApplicationData }) => {
       fieldName: 'Document rendered on',
       fieldValue: (
         <Text style={styles.tableValue}>
-          {getFormattedDate(Date.now(), TIME_DAY_AND_DATE_FORMAT)}
+          {getFormattedDate(Date.now(), DateFormat.TIME_DAY_AND_DATE_FORMAT)}
         </Text>
       ),
     },

--- a/components/pages/Applications/PDF/Cover.tsx
+++ b/components/pages/Applications/PDF/Cover.tsx
@@ -26,7 +26,7 @@ import { getDisplayName, PDFText, PDFTitle } from './common';
 import VerticalTable from './VerticalTable';
 import { ApplicationData } from '../types';
 import { getFormattedDate } from '../Dashboard/Applications/InProgress/helpers';
-import { TIME_DAY_AND_DATE_FORMAT } from '../Dashboard/Applications/InProgress/constants';
+import { TIME_DAY_AND_DATE_FORMAT } from 'global/utils/dates/constants';
 import { FieldAccessor } from './types';
 
 const styles = StyleSheet.create({

--- a/components/pages/Applications/PDF/common.tsx
+++ b/components/pages/Applications/PDF/common.tsx
@@ -22,7 +22,6 @@ import { Text, View, Font, StyleSheet } from '@react-pdf/renderer';
 import defaultTheme from '@icgc-argo/uikit/theme/defaultTheme';
 import Typography from '@icgc-argo/uikit/Typography';
 import Link from '@icgc-argo/uikit/Link';
-import { format } from 'date-fns';
 import Button from '@icgc-argo/uikit/Button';
 import { css } from '@icgc-argo/uikit';
 import Banner from '@icgc-argo/uikit/notifications/Banner';
@@ -31,7 +30,8 @@ import PDFLayout from './PdfLayout';
 import EmptyCheckbox from './icons/EmptyCheckbox';
 import FilledCheckbox from './icons/FilledCheckbox';
 import { FieldAccessor, PdfField, PdfFieldName, PdfFormField } from './types';
-import { DATE_TEXT_FORMAT } from 'global/utils/dates/constants';
+import { DateFormat } from 'global/utils/dates/types';
+import { getFormattedDate } from 'global/utils/dates/helpers';
 
 const WorkSansBold = require('public/fonts/WorkSans-Bold.ttf').default;
 const WorkSansLight = require('public/fonts/WorkSans-Light.ttf').default;
@@ -274,7 +274,7 @@ export const UITitle = ({
             `
           }
         >
-          Last updated: {format(new Date(sectionLastUpdatedAt), DATE_TEXT_FORMAT)}
+          Last updated: {getFormattedDate(sectionLastUpdatedAt, DateFormat.DATE_TEXT_FORMAT)}
         </Typography>
       )}
     </Typography>

--- a/components/pages/Applications/PDF/common.tsx
+++ b/components/pages/Applications/PDF/common.tsx
@@ -31,7 +31,7 @@ import PDFLayout from './PdfLayout';
 import EmptyCheckbox from './icons/EmptyCheckbox';
 import FilledCheckbox from './icons/FilledCheckbox';
 import { FieldAccessor, PdfField, PdfFieldName, PdfFormField } from './types';
-import { DATE_TEXT_FORMAT } from 'global/constants';
+import { DATE_TEXT_FORMAT } from 'global/utils/dates/constants';
 
 const WorkSansBold = require('public/fonts/WorkSans-Bold.ttf').default;
 const WorkSansLight = require('public/fonts/WorkSans-Light.ttf').default;

--- a/components/pages/Applications/types.ts
+++ b/components/pages/Applications/types.ts
@@ -116,6 +116,7 @@ export type ApplicationSummary = {
   isRenewal: boolean;
   ableToRenew: boolean;
   renewalAppId?: string;
+  expiredEventDateUtc?: string;
 };
 
 export type ApplicationDataByField = {
@@ -310,6 +311,7 @@ export interface ApplicationData {
   attestationByUtc?: string;
   lastPausedAtUtc?: string;
   updates: ApplicationUpdate[] | UserViewApplicationUpdate[];
+  expiredEventDateUtc?: string;
   sections: {
     applicant: Individual;
     representative: Representative;

--- a/global/constants/index.ts
+++ b/global/constants/index.ts
@@ -26,10 +26,6 @@ export const EGO_JWT_KEY = 'egoJwt';
 export const ADMIN_APPLICATIONS_LABEL = 'Manage Applications';
 export const APPLICANT_APPLICATIONS_LABEL = 'My Applications';
 
-export const DATE_RANGE_DISPLAY_FORMAT = 'Y-MM-dd';
-
-export const DATE_TEXT_FORMAT = 'MMM. dd, yyyy';
-
 export const SUBMISSION_SUCCESS_CHECK = 'daco.submission-success-check';
 export const APPROVED_APP_CLOSED_CHECK = 'daco.approved-app-closed-check';
 export const GDPR_ACCEPTED = 'gdpr-accepted';

--- a/global/utils/dates/constants.ts
+++ b/global/utils/dates/constants.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 The Ontario Institute for Cancer Research. All rights reserved
+ * Copyright (c) 2023 The Ontario Institute for Cancer Research. All rights reserved
  *
  * This program and the accompanying materials are made available under the terms of
  * the GNU Affero General Public License v3.0. You should have received a copy of the
@@ -17,6 +17,8 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+export const DATE_RANGE_DISPLAY_FORMAT = 'Y-MM-dd';
+export const DATE_TEXT_FORMAT = 'MMM. dd, yyyy';
 export const TIME_AND_DATE_FORMAT = "MMM. dd, yyyy 'at' h:mm aaaa";
 export const FILE_DATE_FORMAT = 'yyyyMMdd';
 export const TIME_DAY_AND_DATE_FORMAT = "EEE. MMM. dd, yyyy 'at' h:mm aaaa";

--- a/global/utils/dates/helpers.ts
+++ b/global/utils/dates/helpers.ts
@@ -1,4 +1,3 @@
-import { ApplicationUpdate, UpdateEvent } from 'components/pages/Applications/types';
 import { addDays, format, isAfter } from 'date-fns';
 import { DateFormat } from './types';
 
@@ -23,9 +22,4 @@ export const getFormattedDate = (value: string | number | Date, dateFormat: Date
     return '';
   }
   return format(valueAsDate, dateFormat);
-};
-
-export const getExpiredAtDate = (appUpdates: ApplicationUpdate[], expiresAtUtc: string): string => {
-  const expiryEvent = appUpdates.find((update) => update.eventType === UpdateEvent.EXPIRED);
-  return expiryEvent?.date || expiresAtUtc;
 };

--- a/global/utils/dates/helpers.ts
+++ b/global/utils/dates/helpers.ts
@@ -1,4 +1,6 @@
-import { addDays, isAfter } from 'date-fns';
+import { ApplicationUpdate, UpdateEvent } from 'components/pages/Applications/types';
+import { addDays, format, isAfter } from 'date-fns';
+import { DateFormat } from './types';
 
 // calculate the last day an app can be renewed, expiry + configured days post expiry
 // DACO allows 90 days after expiry to renew
@@ -12,4 +14,18 @@ export const isRenewalPeriodEnded = (expiryDate: string): boolean => {
   const now = new Date();
   const endDate = new Date(getRenewalPeriodEndDate(expiryDate));
   return isAfter(now, endDate);
+};
+
+export const getFormattedDate = (value: string | number | Date, dateFormat: DateFormat): string => {
+  const valueAsDate = new Date(value);
+  if (valueAsDate.toString() === 'Invalid Date') {
+    console.warn(`${value} is not a valid date.`);
+    return '';
+  }
+  return format(valueAsDate, dateFormat);
+};
+
+export const getExpiredAtDate = (appUpdates: ApplicationUpdate[], expiresAtUtc: string): string => {
+  const expiryEvent = appUpdates.find((update) => update.eventType === UpdateEvent.EXPIRED);
+  return expiryEvent?.date || expiresAtUtc;
 };

--- a/global/utils/dates/types.ts
+++ b/global/utils/dates/types.ts
@@ -17,11 +17,12 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-export const DATE_RANGE_DISPLAY_FORMAT = 'Y-MM-dd';
-export const DATE_TEXT_FORMAT = 'MMM. dd, yyyy';
-export const TIME_AND_DATE_FORMAT = "MMM. dd, yyyy 'at' h:mm aaaa";
-export const FILE_DATE_FORMAT = 'yyyyMMdd';
-export const TIME_DAY_AND_DATE_FORMAT = "EEE. MMM. dd, yyyy 'at' h:mm aaaa";
-export const UPLOAD_DATE_FORMAT = 'yyyy-MM-dd';
-// API_DEFAULT_DATE_FORMAT is ISO8601
-export const API_DEFAULT_DATE_FORMAT = "yyyy-MM-ddTHH:mm:ss'Z'";
+export enum DateFormat {
+  DATE_RANGE_DISPLAY_FORMAT = 'Y-MM-dd',
+  DATE_TEXT_FORMAT = 'MMM. dd, yyyy',
+  TIME_AND_DATE_FORMAT = "MMM. dd, yyyy 'at' h:mm aaaa",
+  FILE_DATE_FORMAT = 'yyyyMMdd',
+  TIME_DAY_AND_DATE_FORMAT = "EEE. MMM. dd, yyyy 'at' h:mm aaaa",
+  UPLOAD_DATE_FORMAT = 'yyyy-MM-dd',
+  API_DEFAULT_DATE_FORMAT = "yyyy-MM-ddTHH:mm:ss'Z'", // API_DEFAULT_DATE_FORMAT is ISO8601
+}


### PR DESCRIPTION
Reorganize date format constants into enums, add to global/dates folder.
Move `getFormattedDate` helper func to global/dates folder. Add error clause.
Replace most `date-fns/format` calls with helper func.
**Does not modify/remove DateFormat string options, should discuss whether any of these can be pruned first.**