### PR TITLE
💄 515 - admin table - move type column after app status column

### DIFF
--- a/components/pages/Applications/ManageApplications/utils.tsx
+++ b/components/pages/Applications/ManageApplications/utils.tsx
@@ -156,18 +156,18 @@ export const tableColumns: TableColumnConfig<ApplicationRecord> & {
         : null,
   },
   {
-    Header: fieldDisplayNames.type,
-    id: ApplicationsField.type,
-    accessor: 'type',
-    Cell: ({ original }: { original: ApplicationRecord }) =>
-      original.isRenewal ? 'Renewal' : 'New',
-  },
-  {
     Header: fieldDisplayNames.state,
     id: ApplicationsField.state,
     accessor: 'status',
     Cell: ({ original }: { original: ApplicationRecord }) =>
       startCase(original.status.toLowerCase()),
+  },
+  {
+    Header: fieldDisplayNames.type,
+    id: ApplicationsField.type,
+    accessor: 'type',
+    Cell: ({ original }: { original: ApplicationRecord }) =>
+      original.isRenewal ? 'Renewal' : 'New',
   },
 ];
 


### PR DESCRIPTION
Move type column after app status column in admin table view so status shows without need for horizontal scroll.