### PR TITLE
🐛 689 - add custom month abbr for date formatter

### DIFF
--- a/components/pages/Applications/ApplicationForm/Header/index.tsx
+++ b/components/pages/Applications/ApplicationForm/Header/index.tsx
@@ -18,7 +18,6 @@
  */
 
 import { ReactElement } from 'react';
-import { format } from 'date-fns';
 import styled from '@emotion/styled-base';
 import { css } from '@icgc-argo/uikit';
 import { UikitTheme } from '@icgc-argo/uikit/index';
@@ -180,11 +179,7 @@ const ApplicationHeader = ({
           appId={appId}
           applicant={applicant}
           createdAt={getFormattedDate(createdAtUtc, DateFormat.DATE_TEXT_FORMAT)}
-          // using format() here because DATE_TEXT_FORMAT + ' h:mm aaaa' was not added as a DateFormat enum, may be removed/replaced by TIME_AND_DATE_FORMAT
-          lastUpdated={format(
-            new Date(lastUpdatedAtUtc),
-            DateFormat.DATE_TEXT_FORMAT + ' h:mm aaaa',
-          )}
+          lastUpdated={getFormattedDate(lastUpdatedAtUtc, DateFormat.TIME_DATE_FORMAT)}
           accessInfo={accessInfo}
         />
 

--- a/components/pages/Applications/Dashboard/Applications/InProgress/helpers.ts
+++ b/components/pages/Applications/Dashboard/Applications/InProgress/helpers.ts
@@ -18,7 +18,6 @@
  */
 
 import { pick } from 'lodash';
-import { format as formatDate } from 'date-fns';
 
 import { ApplicationState } from 'components/ApplicationProgressBar/types';
 import { ApplicationSummary } from 'components/pages/Applications/types';
@@ -54,7 +53,7 @@ export const getStatusText = (application: ApplicationSummary) => {
   };
 
   const formatStatusDate = (date: string) =>
-    formatDate(new Date(date || dates.lastUpdatedAtUtc), DateFormat.DATE_TEXT_FORMAT);
+    getFormattedDate(date || dates.lastUpdatedAtUtc, DateFormat.DATE_TEXT_FORMAT);
 
   const revisionsRequestedText = `${
     isRenewal ? 'Renewal reopened' : 'Reopened'

--- a/components/pages/Applications/Dashboard/Applications/InProgress/index.tsx
+++ b/components/pages/Applications/Dashboard/Applications/InProgress/index.tsx
@@ -232,7 +232,7 @@ const InProgress = ({ application }: { application: ApplicationSummary }) => {
           </div>
           <div>
             <b>Last Updated:</b>{' '}
-            {getFormattedDate(lastUpdatedAtUtc, DateFormat.TIME_AND_DATE_FORMAT)}
+            {getFormattedDate(lastUpdatedAtUtc, DateFormat.TIME_AND_DATE_AT_FORMAT)}
           </div>
         </Typography>
 

--- a/global/utils/dates/helpers.ts
+++ b/global/utils/dates/helpers.ts
@@ -1,7 +1,7 @@
 import { ApplicationState } from 'components/ApplicationProgressBar/types';
 import { ApplicationData } from 'components/pages/Applications/types';
 import { format, isAfter } from 'date-fns';
-
+import { enUS } from 'date-fns/locale';
 import { DateFormat } from './types';
 
 export const isRenewalPeriodEnded = (sourceRenewalPeriodEndDateUtc?: string): boolean => {
@@ -25,11 +25,36 @@ export const sourceAppIsWithinRenewalPeriod = (appData: ApplicationData): boolea
   );
 };
 
+// customize month abbreviations so DateFormat does not need to add a '.'
+// ensures May does not get an unnecessary '.'
+const monthAbbr: string[] = [
+  'Jan.',
+  'Feb.',
+  'Mar.',
+  'Apr.',
+  'May',
+  'Jun.',
+  'Jul.',
+  'Aug.',
+  'Sep.',
+  'Oct.',
+  'Nov.',
+  'Dec.',
+];
+
+const customLocale = {
+  ...enUS,
+  localize: {
+    ...enUS.localize,
+    month: (token: number) => monthAbbr[token],
+  } as Locale['localize'],
+};
+
 export const getFormattedDate = (value: string | number | Date, dateFormat: DateFormat): string => {
   const valueAsDate = new Date(value);
   if (valueAsDate.toString() === 'Invalid Date') {
     console.warn(`${value} is not a valid date.`);
     return '';
   }
-  return format(valueAsDate, dateFormat);
+  return format(valueAsDate, dateFormat, { locale: customLocale });
 };

--- a/global/utils/dates/types.ts
+++ b/global/utils/dates/types.ts
@@ -19,10 +19,11 @@
 
 export enum DateFormat {
   DATE_RANGE_DISPLAY_FORMAT = 'Y-MM-dd',
-  DATE_TEXT_FORMAT = 'MMM. dd, yyyy',
-  TIME_AND_DATE_FORMAT = "MMM. dd, yyyy 'at' h:mm aaaa",
+  DATE_TEXT_FORMAT = 'MMM dd, yyyy',
+  TIME_AND_DATE_AT_FORMAT = "MMM dd, yyyy 'at' h:mm aaaa",
+  TIME_DATE_FORMAT = 'MMM dd, yyyy h:mm aaaa',
   FILE_DATE_FORMAT = 'yyyyMMdd',
-  TIME_DAY_AND_DATE_FORMAT = "EEE. MMM. dd, yyyy 'at' h:mm aaaa",
+  TIME_DAY_AND_DATE_FORMAT = "EEE. MMM dd, yyyy 'at' h:mm aaaa",
   UPLOAD_DATE_FORMAT = 'yyyy-MM-dd',
   API_DEFAULT_DATE_FORMAT = "yyyy-MM-ddTHH:mm:ss'Z'", // API_DEFAULT_DATE_FORMAT is ISO8601
 }


### PR DESCRIPTION
Extends date-fns locale with custom month abbreviations, so ending `.` is not required in date format string types
- ensures `May` does not get an unnecessary `.`
- all dates are formatted with `getFormattedDate` helper func